### PR TITLE
Add VirtualBank design blueprint and documentation refresh

### DIFF
--- a/Changelog/Changelog.md
+++ b/Changelog/Changelog.md
@@ -1,0 +1,6 @@
+# Changelog
+
+## [2025-09-25] VirtualBank Design Documentation
+- **Change Type:** Standard Change
+- **Reason:** Establish a cohesive blueprint and updated documentation to guide upcoming development of the VirtualBank experience.
+- **What Changed:** Added a comprehensive design document (`designing/design.md`) covering frontend, middleware, and backend architecture, and refreshed the main README to highlight the design vision and documentation structure.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,20 @@
 # VirtualBank
-Just a simple Virual Bank Simulator. No actual Money used. No bank Connectors etc...
+
+VirtualBank is a playful online banking simulator that lets users explore modern money-management journeys with a fictional fun-currency. The platform focuses on safe experimentation—no real funds or external bank connectors are involved.
+
+## Highlights
+- **Best-in-class UX** with responsive, accessible interfaces and gamified feedback loops.
+- **Modular architecture** spanning a rich frontend, a secure middleware gateway, and resilient backend microservices.
+- **Fictional currency** that mimics real banking flows without touching actual money.
+
+## Project Structure
+- `designing/design.md` – End-to-end blueprint covering frontend, middleware, and backend design decisions.
+- `Changelog/Changelog.md` – Running log of product and documentation updates.
+
+## Getting Started
+1. Clone the repository.
+2. Explore the design blueprint in [`designing/design.md`](designing/design.md) to understand the planned experience and architecture.
+3. Follow upcoming implementation guides (to be added) to bring the VirtualBank vision to life.
+
+## Contributing
+We welcome thoughtful contributions that keep the experience modern, accessible, and fun. Please update the changelog and documentation with every meaningful change.

--- a/designing/design.md
+++ b/designing/design.md
@@ -1,0 +1,99 @@
+# VirtualBank Design Blueprint
+
+## 1. Vision & Experience Goals
+- Deliver a "Best UX Ever" feeling through responsive interactions, intuitive flows, and delightful microcopy.
+- Emphasize that VirtualBank uses a playful, fictional currency while still modeling authentic banking behaviors.
+- Maintain modularity across the stack to support rapid iteration and feature expansion.
+
+## 2. Architecture Overview
+- **Client (Frontend)**: React-based single-page application that consumes RESTful APIs and real-time event streams.
+- **Middleware**: Node.js service acting as an API gateway and orchestrator, responsible for request validation, caching, and security enforcement.
+- **Backend Services**: Microservice suite implemented with TypeScript (NestJS) and PostgreSQL for persistent storage, accompanied by a Redis instance for ephemeral data.
+- **Infrastructure**: Containerized deployment using Docker and Kubernetes, with CI/CD pipelines enforcing quality gates and automated testing.
+
+```
+[Frontend SPA] ⇄ [Middleware Gateway] ⇄ [Core Banking Microservices]
+                                      ⇅
+                                  [Data Stores]
+```
+
+## 3. Frontend Experience Design
+### 3.1 Technology Stack
+- React + TypeScript with Vite for rapid development.
+- Styled Components or Tailwind CSS for themeable design tokens.
+- React Query for data fetching and caching.
+- Storybook for component documentation.
+
+### 3.2 Design System
+- **Visual Language**: Minimalistic with bold accent colors inspired by digital wallets. Dark and light themes available.
+- **Components**: Modular atoms (buttons, typography, badges), molecules (account cards, transaction list items), and organisms (dashboard, transfer wizard).
+- **Interactions**: Animated transitions for navigation, haptic feedback cues for mobile, and optimistic UI updates for immediate responses.
+
+### 3.3 Core User Flows
+1. **Onboarding**: Guided setup with playful copy explaining the fun currency concept.
+2. **Dashboard**: Dynamic overview of accounts, recent transactions, and gamified achievements.
+3. **Transfer Wizard**: Three-step wizard with smart defaults, validation, and confirmation modals.
+4. **Insights & Analytics**: Charts powered by D3 or Recharts, providing spending summaries and projections.
+5. **Settings & Accessibility**: Full keyboard navigation, ARIA labels, adjustable font sizes, and localization support.
+
+### 3.4 State Management & Data Handling
+- Global app state via Zustand or Redux Toolkit (lightweight slices for session, accounts, and settings).
+- WebSocket channel for streaming transaction updates and notifications.
+- Offline-first capabilities with service workers and IndexedDB caching.
+
+## 4. Middleware Design
+### 4.1 Responsibilities
+- Central gateway for REST and WebSocket traffic.
+- Request authentication (JWT validation, API keys for third-party integrations).
+- Rate limiting, throttling, and caching strategies to protect backend services.
+- Aggregation layer to combine data from multiple microservices before returning responses.
+
+### 4.2 Implementation Details
+- Node.js with Fastify for high throughput and schema-based validation using TypeBox.
+- Policy-based access control to manage feature toggles and user roles.
+- Circuit breakers and retries (e.g., using the `opossum` library) for resilient downstream calls.
+- Structured logging (pino) and distributed tracing (OpenTelemetry) to maintain observability.
+
+## 5. Backend Design
+### 5.1 Service Composition
+- **Account Service**: Manages virtual accounts, balances, and account metadata.
+- **Transaction Service**: Handles transfers, batch operations, and ledger entries.
+- **Rewards Service**: Tracks gamified achievements and fun-currency rewards.
+- **Notification Service**: Sends real-time updates via email, push, or in-app alerts.
+
+### 5.2 Data Modeling
+- PostgreSQL schemas with strict referential integrity and JSONB columns for extensible metadata.
+- Event sourcing for transaction events, allowing auditing and replay capabilities.
+- Redis streams for queuing asynchronous tasks and facilitating pub/sub patterns.
+
+### 5.3 APIs & Integrations
+- REST endpoints following JSON:API conventions with pagination, filtering, and sorting.
+- GraphQL gateway (optional) for complex dashboard queries.
+- Webhooks to trigger automation scenarios (e.g., achievements unlocked).
+- Integration tests run via Jest and Pact for contract validation.
+
+## 6. Security & Compliance
+- Role-Based Access Control with scoped permissions (admin, auditor, customer).
+- Data encryption at rest (PostgreSQL TDE) and in transit (TLS everywhere).
+- Static code analysis and dependency scanning in CI/CD.
+- Audit trails for administrative actions, accessible via dedicated tooling.
+- Clear disclaimers that all currency is fictional to avoid regulatory ambiguity.
+
+## 7. Observability & Operations
+- Centralized logging (ELK stack) and metrics (Prometheus + Grafana dashboards).
+- Synthetic monitoring to emulate user journeys and track UX health KPIs.
+- Automated chaos testing in non-production environments to ensure resilience.
+
+## 8. UX Best Practices Checklist
+- Keep primary CTAs above the fold with high contrast.
+- Provide celebratory animations when users complete tasks.
+- Offer contextual tips explaining fake currency mechanics.
+- Ensure loading states, skeleton screens, and error recovery flows are polished.
+
+## 9. Roadmap Considerations
+- Gamified leaderboards comparing friendly virtual wealth.
+- API marketplace for community-built fun currency extensions.
+- AI-driven financial coaching for playful budget recommendations.
+
+## 10. Summary
+VirtualBank's design blends modern architecture with a whimsical yet secure user experience. By separating concerns across the frontend, middleware, and backend, the platform remains modular, scalable, and delightful for users exploring virtual finance.


### PR DESCRIPTION
## Summary
- add a comprehensive VirtualBank design blueprint covering frontend, middleware, and backend architecture
- refresh the README to highlight the vision, key highlights, and documentation structure
- log the documentation update in the changelog with change type, reason, and details

## Testing
- not run (documentation-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68d55a176b6c8333ac479ff36110000b