### PR TITLE
Add market simulation service design

### DIFF
--- a/Changelog/Changelog.md
+++ b/Changelog/Changelog.md
@@ -9,3 +9,8 @@
 - **Change Type:** Normal Change
 - **Reason:** Capture the newly defined multi-user gameplay expectations and virtual economy mechanics requested for the next design iteration.
 - **What Changed:** Expanded `designing/design.md` with role-aware flows, backend services for credits and yields, and dedicated economy governance guidance; refreshed the README highlights to showcase the multi-user world, and documented the update here.
+
+## [2025-09-27] Market Simulation Expansion
+- **Change Type:** Normal Change
+- **Reason:** Introduce a modular stock market sandbox that lets players trade fictional equities with organic price movements and fair safeguards.
+- **What Changed:** Augmented `designing/design.md` with a market simulation bounded context, covering market-data generation, matching, portfolios, risk, and analytics; expanded frontend flows for the Market Desk experience; refreshed the README highlights and structure references to spotlight the new service.

--- a/README.md
+++ b/README.md
@@ -7,9 +7,11 @@ VirtualBank is a playful online banking simulator that lets users explore modern
 - **Modular architecture** spanning a rich frontend, a secure middleware gateway, and resilient backend microservices.
 - **Multi-user economy** where every player controls a personal account, Game Masters steward the world, and the system supports credits, yields, and diverse income streams.
 - **Fictional currency** that mimics real banking flows without touching actual money.
+- **Dynamic stock market sandbox** featuring AI-driven price regimes, sector indices, and fair-play trading mechanics for users to buy and sell virtual equities.
 
 ## Project Structure
 - `designing/design.md` – End-to-end blueprint covering frontend, middleware, and backend design decisions.
+- Market simulation architecture, gameplay surfaces, and risk controls are detailed in Section 5.4 of the design blueprint.
 - `Changelog/Changelog.md` – Running log of product and documentation updates.
 
 ## Getting Started

--- a/designing/design.md
+++ b/designing/design.md
@@ -10,6 +10,7 @@
 - **Client (Frontend)**: React-based single-page application that consumes RESTful APIs and real-time event streams.
 - **Middleware**: Node.js service acting as an API gateway and orchestrator, responsible for request validation, caching, and security enforcement.
 - **Backend Services**: Microservice suite implemented with TypeScript (NestJS) and PostgreSQL for persistent storage, accompanied by a Redis instance for ephemeral data.
+- **Market Simulation Context**: Independent stock-market sandbox exposed through APIs and event streams, operating alongside the middleware while respecting shared observability and identity standards.
 - **Infrastructure**: Containerized deployment using Docker and Kubernetes, with CI/CD pipelines enforcing quality gates and automated testing.
 
 ```
@@ -35,14 +36,17 @@
 2. **Dashboard**: Dynamic overview of accounts, recent transactions, credit utilization, and gamified achievements.
 3. **Transfer Wizard**: Three-step wizard with smart defaults, validation, and confirmation modals.
 4. **Insights & Analytics**: Charts powered by D3 or Recharts, providing spending summaries, projections, and simulated yield forecasts.
-5. **Settings & Accessibility**: Full keyboard navigation, ARIA labels, adjustable font sizes, and localization support.
-6. **Game Master Console**: Administrative tools to mint events, approve credit lines, review community metrics, and broadcast announcements.
+5. **Market Desk**: Multi-pane workspace featuring watchlists, heatmaps, order books (Level-2), candlestick charts, depth views, and a news ticker with sentiment badges.
+6. **Trade Ticket**: Context-aware ticket supporting market/limit/stop orders, position summaries, P&L badges, and fee previews.
+7. **Settings & Accessibility**: Full keyboard navigation, ARIA labels, adjustable font sizes, and localization support.
+8. **Game Master Console**: Administrative tools to mint events, approve credit lines, review community metrics, and broadcast announcements.
 
 ### 3.4 State Management & Data Handling
 - Global app state via Zustand or Redux Toolkit (lightweight slices for session, accounts, settings, and role capabilities).
 - WebSocket channel for streaming transaction updates and notifications.
 - Offline-first capabilities with service workers and IndexedDB caching.
 - Shared caches keyed by user + tenant identifiers to isolate multi-user data and Game Master broadcast streams.
+- Dedicated market data store slice supporting snapshot + incremental updates, with throttled rendering for high-frequency tick data.
 
 ### 3.5 Role-Specific Experience Design
 - **Players**: Personalized dashboards showing liquid balance, outstanding credit, investment products, and passive income trackers.
@@ -73,6 +77,7 @@
 - **Yield & Income Service**: Simulates savings products, distributes interest accruals, and orchestrates passive income mechanics (e.g., virtual staking pools, quests).
 - **Rewards Service**: Tracks gamified achievements and fun-currency rewards.
 - **Notification Service**: Sends real-time updates via email, push, or in-app alerts.
+- **Market Gateway**: Bridges the middleware with the market simulation context, translating authenticated player intents into market-safe commands and streaming market data back to clients.
 
 ### 5.2 Data Modeling
 - PostgreSQL schemas with strict referential integrity and JSONB columns for extensible metadata.
@@ -87,6 +92,42 @@
 - GraphQL gateway (optional) for complex dashboard queries.
 - Webhooks to trigger automation scenarios (e.g., achievements unlocked).
 - Integration tests run via Jest and Pact for contract validation.
+
+### 5.4 Market Simulation Bounded Context
+The market simulation operates as a modular suite of services that can evolve independently while integrating through clear APIs.
+
+- **Market-Data Service**
+  - Generates synthetic ticks and bars with organic behaviors (trend phases, volatility clusters, and stochastic jump events).
+  - Maintains sector-based indices (Tech, Energy, Meme, Industrials, BankSim) and a headline composite index driven by beta-weighted components.
+  - Emits generated corporate news with sentiment tags (🟢 bullish, 🔴 bearish) and estimated impact to drive regime shifts.
+  - Hosts a regime scheduler that cycles through Calm, Trend Up/Down, High Volatility, and Crash/Boom states with configurable dwell times and decay curves.
+
+- **Matching Engine**
+  - Supports market, limit, and stop orders with price-time priority, plus opening/closing call auctions.
+  - Implements an order book with Level-2 depth snapshots, trades tape streaming, and circuit breakers that trigger halts on extreme moves.
+  - Applies maker/taker fees and simulates slippage during high-volatility intervals to keep the experience fair yet exciting.
+
+- **Portfolio Service**
+  - Tracks holdings per user with FIFO/LIFO lot metadata, unrealized and realized P&L, and dividend accrual events tied to company schedules.
+  - Maintains tax-disclaimer messaging reminding players that the fun currency is outside real-world regulation.
+  - Provides portfolio analytics for dashboards, including exposure by sector and risk-adjusted fun metrics.
+
+- **Risk & Surveillance Service**
+  - Monitors positional limits, volatility exposure, and leverage across users.
+  - Detects suspicious patterns (wash trading, self-trading, spoofing) and can enforce cooldowns or auto-cancel orders.
+  - Coordinates with the matching engine to issue circuit-breaker banners and communicate halts via system notices.
+
+- **Leaderboard & Analytics Service**
+  - Calculates realized gains, rolling Sharpe-like fun ratios, and seasonal event standings.
+  - Powers watchlists, heatmaps, depth charts, and circuit-breaker alerts for the Market Desk UI.
+  - Archives historical bars for charting and simulation replays.
+
+### 5.5 Market Simulation Data & Integration
+- **Data Stores**: Timeseries database (TimescaleDB extension on PostgreSQL) for tick/bar storage, Redis for real-time order books, and object storage for replay bundles.
+- **API Contracts**: REST and WebSocket endpoints for market data, order routing, and portfolio insights. Middleware signs requests using user identity claims and relays event streams via topic-based channels.
+- **Correlation Modeling**: Sector covariance matrices drive correlated noise injected into ticker generation. Index drift factors apply beta-weighted adjustments to constituent prices.
+- **Event Engine**: Crash/boom injections apply jump-diffusion adjustments with exponential decay, while dividend days and earnings simulations trigger news, pricing gaps, and trade halts.
+- **Fair-Play Controls**: Rate limits per user, per-instrument position caps, and configurable cooldowns post-halt prevent exploitative behavior.
 
 ## 6. Security & Compliance
 - Role-Based Access Control with scoped permissions (admin, auditor, customer).
@@ -119,6 +160,7 @@
 - **Income Generation**: Players earn through quests, marketplace gigs, referral bonuses, staking pools, and collaborative ventures. Automation rules allow steady passive income drops while keeping total supply in check.
 - **Game Master Controls**: Central dashboards to set macroeconomic levers (base interest rate, credit risk multipliers, event-based multipliers) and to simulate stress scenarios.
 - **Economy Health Monitoring**: KPIs such as total circulating currency, credit default ratios, yield payout velocity, and per-user wealth distribution feed into dashboards for proactive balancing.
+- **Virtual Stock Market**: Fictional companies grouped by sector issue shares whose prices respond to regime schedules, news impacts, and user trading activity. Game Masters can trigger special events (earnings sims, dividend days, meme rallies) to influence liquidity and volatility.
 
 ## 11. Summary
 VirtualBank's design blends modern architecture with a whimsical yet secure user experience. By separating concerns across the frontend, middleware, and backend, the platform remains modular, scalable, and delightful for users exploring virtual finance.


### PR DESCRIPTION
## Summary
- expand the architecture overview and backend blueprint with a dedicated market simulation bounded context
- document market data generation, matching engine, portfolio, risk, and analytics services along with integration patterns
- refresh the README highlights and changelog to surface the new stock market sandbox experience

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d55e1ea5d483339632068484ad8d4c