### PR TITLE
Add stock market dataset seeds

### DIFF
--- a/Changelog/Changelog.md
+++ b/Changelog/Changelog.md
@@ -14,3 +14,8 @@
 - **Change Type:** Normal Change
 - **Reason:** Introduce a modular stock market sandbox that lets players trade fictional equities with organic price movements and fair safeguards.
 - **What Changed:** Augmented `designing/design.md` with a market simulation bounded context, covering market-data generation, matching, portfolios, risk, and analytics; expanded frontend flows for the Market Desk experience; refreshed the README highlights and structure references to spotlight the new service.
+
+## [2025-09-28] Market Dataset Seed
+- **Change Type:** Normal Change
+- **Reason:** Provide ready-made fake companies and starter portfolios to accelerate stock market prototyping.
+- **What Changed:** Added the `dataset/` directory with curated company and portfolio JSON files, refreshed the README to surface the dataset resources, and documented the update here.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,16 @@ VirtualBank is a playful online banking simulator that lets users explore modern
 ## Project Structure
 - `designing/design.md` – End-to-end blueprint covering frontend, middleware, and backend design decisions.
 - Market simulation architecture, gameplay surfaces, and risk controls are detailed in Section 5.4 of the design blueprint.
+- `dataset/` – Curated fake companies and portfolio seeds for market-simulation testing.
 - `Changelog/Changelog.md` – Running log of product and documentation updates.
+
+## Datasets
+The `dataset` folder contains ready-to-use JSON files for stock-market prototyping:
+
+- `fake_companies.json` lists sector-diverse fictional firms with baseline pricing and volatility hints.
+- `sample_portfolios.json` provides example allocations that feature different strategies and risk profiles.
+
+These assets let designers and engineers populate market simulations instantly without crafting data from scratch.
 
 ## Getting Started
 1. Clone the repository.

--- a/dataset/fake_companies.json
+++ b/dataset/fake_companies.json
@@ -1,0 +1,122 @@
+[
+  {
+    "ticker": "AVX",
+    "name": "Aventix Labs",
+    "sector": "Biotech",
+    "region": "North America",
+    "market_cap_millions": 1280,
+    "base_price": 42.15,
+    "volatility": 0.27,
+    "story": "Clinical-stage biotech focused on adaptive antiviral therapies for virtual pandemics."
+  },
+  {
+    "ticker": "BQE",
+    "name": "BlueQuartz Energy",
+    "sector": "Renewable Energy",
+    "region": "Europe",
+    "market_cap_millions": 2245,
+    "base_price": 68.74,
+    "volatility": 0.19,
+    "story": "Utility-scale floating solar arrays powering coastal smart cities across the simulation."
+  },
+  {
+    "ticker": "CRN",
+    "name": "Chronicle Networks",
+    "sector": "Information Technology",
+    "region": "Asia-Pacific",
+    "market_cap_millions": 5100,
+    "base_price": 115.33,
+    "volatility": 0.32,
+    "story": "Latency-free quantum mesh routers connecting gamer guilds and financial hubs."
+  },
+  {
+    "ticker": "DYN",
+    "name": "Dynamo Freight",
+    "sector": "Logistics",
+    "region": "North America",
+    "market_cap_millions": 1875,
+    "base_price": 57.9,
+    "volatility": 0.22,
+    "story": "Autonomous freight pods coordinating real-time supply chains for virtual retailers."
+  },
+  {
+    "ticker": "ELM",
+    "name": "Elm Grove Foods",
+    "sector": "Consumer Staples",
+    "region": "South America",
+    "market_cap_millions": 930,
+    "base_price": 24.68,
+    "volatility": 0.15,
+    "story": "Vertical farm collectives supplying nutrient-rich produce to megacities."
+  },
+  {
+    "ticker": "FLR",
+    "name": "Flarion Entertainment",
+    "sector": "Media & Gaming",
+    "region": "Global",
+    "market_cap_millions": 3025,
+    "base_price": 73.41,
+    "volatility": 0.35,
+    "story": "Immersive holo-arenas broadcasting esports and narrative-driven interactive dramas."
+  },
+  {
+    "ticker": "GHC",
+    "name": "GreenHorizon Capital",
+    "sector": "Financial Services",
+    "region": "Europe",
+    "market_cap_millions": 1460,
+    "base_price": 39.28,
+    "volatility": 0.18,
+    "story": "Impact-focused investment firm underwriting sustainability ventures in-game."
+  },
+  {
+    "ticker": "HYS",
+    "name": "HydraSynth Materials",
+    "sector": "Advanced Materials",
+    "region": "Asia-Pacific",
+    "market_cap_millions": 2675,
+    "base_price": 88.05,
+    "volatility": 0.29,
+    "story": "Programmable composites enabling adaptive architecture and vehicles."
+  },
+  {
+    "ticker": "ION",
+    "name": "Ionwave Mobility",
+    "sector": "Transportation",
+    "region": "Middle East",
+    "market_cap_millions": 1988,
+    "base_price": 64.57,
+    "volatility": 0.24,
+    "story": "Hyperloop corridors and aerial taxis linking trade oases and financial districts."
+  },
+  {
+    "ticker": "JDE",
+    "name": "JadeEcho Studios",
+    "sector": "Media & Gaming",
+    "region": "Asia-Pacific",
+    "market_cap_millions": 1580,
+    "base_price": 51.92,
+    "volatility": 0.31,
+    "story": "Story-forward interactive cinema fusing live performers with AI companions."
+  },
+  {
+    "ticker": "KRS",
+    "name": "Kerasan Health",
+    "sector": "Healthcare",
+    "region": "North America",
+    "market_cap_millions": 2750,
+    "base_price": 89.77,
+    "volatility": 0.26,
+    "story": "Telehealth cooperative offering personalized care navigation in the metaverse."
+  },
+  {
+    "ticker": "LUM",
+    "name": "LumenForge Systems",
+    "sector": "Industrial Tech",
+    "region": "Europe",
+    "market_cap_millions": 3210,
+    "base_price": 97.65,
+    "volatility": 0.28,
+    "story": "Photon-powered fabrication plants producing modular infrastructure kits."
+  }
+]

--- a/dataset/sample_portfolios.json
+++ b/dataset/sample_portfolios.json
@@ -1,0 +1,51 @@
+[
+  {
+    "portfolio_id": "PF-ALPHA",
+    "name": "Alpha Growth",
+    "strategy": "High-conviction growth in emerging tech and media leaders.",
+    "risk_profile": "Aggressive",
+    "cash_reserve": 25000,
+    "holdings": [
+      { "ticker": "CRN", "shares": 120 },
+      { "ticker": "FLR", "shares": 180 },
+      { "ticker": "HYS", "shares": 90 }
+    ]
+  },
+  {
+    "portfolio_id": "PF-BAL",
+    "name": "Balanced Horizons",
+    "strategy": "Blend of defensive staples and innovative infrastructure plays.",
+    "risk_profile": "Moderate",
+    "cash_reserve": 40000,
+    "holdings": [
+      { "ticker": "ELM", "shares": 260 },
+      { "ticker": "LUM", "shares": 85 },
+      { "ticker": "AVX", "shares": 150 },
+      { "ticker": "GHC", "shares": 210 }
+    ]
+  },
+  {
+    "portfolio_id": "PF-IMPACT",
+    "name": "Impact Pulse",
+    "strategy": "Sustainability-forward companies delivering measurable eco returns.",
+    "risk_profile": "Moderate",
+    "cash_reserve": 30000,
+    "holdings": [
+      { "ticker": "BQE", "shares": 190 },
+      { "ticker": "GHC", "shares": 160 },
+      { "ticker": "ION", "shares": 140 }
+    ]
+  },
+  {
+    "portfolio_id": "PF-DEF",
+    "name": "Steady Shield",
+    "strategy": "Capital preservation through essential services and logistics.",
+    "risk_profile": "Conservative",
+    "cash_reserve": 52000,
+    "holdings": [
+      { "ticker": "DYN", "shares": 200 },
+      { "ticker": "ELM", "shares": 310 },
+      { "ticker": "KRS", "shares": 95 }
+    ]
+  }
+]


### PR DESCRIPTION
## Summary
- add a dataset directory with curated fake companies and starter portfolios for market simulations
- document the new datasets and their purpose in the README
- log the update in the project changelog

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d55fbd1ca883339390791c75a9a31d