### PR TITLE
Organize design workspaces and refresh architecture overview

### DIFF
--- a/Changelog/Changelog.md
+++ b/Changelog/Changelog.md
@@ -19,3 +19,8 @@
 - **Change Type:** Normal Change
 - **Reason:** Provide ready-made fake companies and starter portfolios to accelerate stock market prototyping.
 - **What Changed:** Added the `dataset/` directory with curated company and portfolio JSON files, refreshed the README to surface the dataset resources, and documented the update here.
+
+## [2025-09-29] Architecture Workspace Setup
+- **Change Type:** Standard Change
+- **Reason:** Organize dedicated design areas and clarify how the stockmarket integrates through the middleware.
+- **What Changed:** Created structured subdirectories under `design/` with placeholder notes, refreshed the architecture overview diagram in `designing/design.md`, and updated the README to surface the new workspace.

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ VirtualBank is a playful online banking simulator that lets users explore modern
 
 ## Project Structure
 - `designing/design.md` – End-to-end blueprint covering frontend, middleware, and backend design decisions.
+- `design/` – Thematic workspaces (`Frontend`, `Middleware`, `Core Banking`, `Data Stores`, `Stockmarket`) ready for focused design notes.
 - Market simulation architecture, gameplay surfaces, and risk controls are detailed in Section 5.4 of the design blueprint.
 - `dataset/` – Curated fake companies and portfolio seeds for market-simulation testing.
 - `Changelog/Changelog.md` – Running log of product and documentation updates.

--- a/design/Core Banking/placeholder.md
+++ b/design/Core Banking/placeholder.md
@@ -1,0 +1,3 @@
+# Core Banking Design Notes
+
+Placeholder for upcoming documentation.

--- a/design/Data Stores/placeholder.md
+++ b/design/Data Stores/placeholder.md
@@ -1,0 +1,3 @@
+# Data Stores Design Notes
+
+Placeholder for upcoming documentation.

--- a/design/Frontend/placeholder.md
+++ b/design/Frontend/placeholder.md
@@ -1,0 +1,3 @@
+# Frontend Design Notes
+
+Placeholder for upcoming documentation.

--- a/design/Middleware/placeholder.md
+++ b/design/Middleware/placeholder.md
@@ -1,0 +1,3 @@
+# Middleware Design Notes
+
+Placeholder for upcoming documentation.

--- a/design/Stockmarket/placeholder.md
+++ b/design/Stockmarket/placeholder.md
@@ -1,0 +1,3 @@
+# Stockmarket Design Notes
+
+Placeholder for upcoming documentation.

--- a/designing/design.md
+++ b/designing/design.md
@@ -8,15 +8,19 @@
 
 ## 2. Architecture Overview
 - **Client (Frontend)**: React-based single-page application that consumes RESTful APIs and real-time event streams.
-- **Middleware**: Node.js service acting as an API gateway and orchestrator, responsible for request validation, caching, and security enforcement.
-- **Backend Services**: Microservice suite implemented with TypeScript (NestJS) and PostgreSQL for persistent storage, accompanied by a Redis instance for ephemeral data.
-- **Market Simulation Context**: Independent stock-market sandbox exposed through APIs and event streams, operating alongside the middleware while respecting shared observability and identity standards.
+- **Middleware Gateway & Stockmarket Bridge**: Node.js service acting as the unified API gateway that validates requests, applies caching and security policies, and routes player intents to both the core banking mesh and the stockmarket simulation.
+- **Core Banking Services**: Microservice suite implemented with TypeScript (NestJS) and PostgreSQL for persistent storage, accompanied by a Redis instance for ephemeral data.
+- **Data Stores**: Polyglot persistence layer combining relational schemas, event streams, and time-series storage for transactional, analytical, and market data needs.
+- **Stockmarket Simulation**: Domain sandbox providing synthetic markets, portfolios, and analytics that integrate with the middleware for identity, telemetry, and governance.
 - **Infrastructure**: Containerized deployment using Docker and Kubernetes, with CI/CD pipelines enforcing quality gates and automated testing.
 
-```
-[Frontend SPA] ⇄ [Middleware Gateway] ⇄ [Core Banking Microservices]
-                                      ⇅
-                                  [Data Stores]
+```mermaid
+graph LR
+    Frontend[Frontend SPA] <--> Middleware[Middleware Gateway &\nStockmarket Bridge]
+    Middleware --> CoreBanking[Core Banking Microservices]
+    CoreBanking --> DataStores[(Data Stores)]
+    Middleware --> StockMarket[Stockmarket Simulation]
+    StockMarket --> DataStores
 ```
 
 ## 3. Frontend Experience Design


### PR DESCRIPTION
## Summary
- add scoped design workspaces for frontend, middleware, core banking, data stores, and stockmarket documentation
- refresh the architecture overview to highlight the middleware-stockmarket bridge and include a clearer diagram
- surface the new design workspace and architecture update in the README and changelog

## Testing
- not run (documentation only)

------
https://chatgpt.com/codex/tasks/task_e_68d561048eb88333a0d1c2c3c3a91ef7