### PR TITLE
Add uxAdmin command center HTML preview

### DIFF
--- a/Changelog/Changelog.md
+++ b/Changelog/Changelog.md
@@ -1,5 +1,15 @@
 # Changelog
 
+-# [2025-10-06] uxAdmin Command Center Preview
+- **Change Type:** Normal Change
+- **Reason:** Provide a tangible HTML preview so stakeholders can experience the proposed administrator control center flow.
+- **What Changed:** Added an interactive `index.html` prototype under `design/Frontend/uxAdmin-control-center/`, refreshed the README to highlight the new preview, and logged the update here.
+
+# [2025-10-05] uxAdmin Command Center Concept
+- **Change Type:** Normal Change
+- **Reason:** Equip administrators with a clear vision for the command center so they can govern the virtual economy confidently.
+- **What Changed:** Added the `design/Frontend/uxAdmin-control-center/` workspace with a design document, feature catalog, and journey map; refreshed the main README and highlighted the new resources.
+
 # [2025-10-04] Frontend Experience Prototypes
 - **Change Type:** Normal Change
 - **Reason:** Craft a warm, professional customer journey that reflects the desired UX-first VirtualBank experience for players and staff.

--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ VirtualBank is a playful online banking simulator that lets users explore modern
   - [`design/Frontend/index.html`](design/Frontend/index.html) – Customer welcome screen with sign-in and registration prototypes.
   - [`design/Frontend/dashboard.html`](design/Frontend/dashboard.html) – Post-login banking overview showcasing account, transfer, and portfolio insights.
   - [`design/Frontend/uxAdmin.html`](design/Frontend/uxAdmin.html) – Staff-only access point with dedicated authentication controls.
+  - [`design/Frontend/uxAdmin-control-center/index.html`](design/Frontend/uxAdmin-control-center/index.html) – Admin command center preview highlighting live oversight, queue triage, and collaboration modules.
+  - [`design/Frontend/uxAdmin-control-center/`](design/Frontend/uxAdmin-control-center/) – Concept workspace for the admin command center, including design rationale, feature catalog, and journey maps.
   - [`design/Middleware/middleware-core-service.md`](design/Middleware/middleware-core-service.md) – Middleware server architecture covering APIs, sagas, SSH operations, and deployment practices.
   - [`design/Stockmarket/stockmarket-simulation.md`](design/Stockmarket/stockmarket-simulation.md) – Real-time market simulation blueprint spanning data generation, matching, risk, and analytics services.
   - [`design/Data Stores/data-store-architecture.md`](design/Data%20Stores/data-store-architecture.md) – High-availability storage blueprint detailing database, cache, and event streaming integrations.
@@ -26,6 +28,8 @@ VirtualBank is a playful online banking simulator that lets users explore modern
 - Open `design/Frontend/index.html` in a browser to explore the player-focused onboarding flow with toggled sign-in and registration states.
 - Visit `design/Frontend/dashboard.html` for a warm, data-rich customer dashboard concept featuring transfers, customer center access, and portfolio highlights.
 - Use `design/Frontend/uxAdmin.html` to review the dedicated administrator entry point at `/uxAdmin` with role-aware access controls.
+- Open `design/Frontend/uxAdmin-control-center/index.html` to preview the command center layout with live status, escalations, and playbook actions.
+- Explore `design/Frontend/uxAdmin-control-center/` for the command center concept, including detailed module definitions and administrator journeys.
 
 ## Datasets
 The `dataset` folder contains ready-to-use JSON files for stock-market prototyping:

--- a/design/Frontend/uxAdmin-control-center/README.md
+++ b/design/Frontend/uxAdmin-control-center/README.md
@@ -1,0 +1,17 @@
+# uxAdmin Control Center Proposal
+
+This workspace collects a concept for the VirtualBank administrator "command center". It outlines
+experience goals, navigation patterns, modular surfaces, and the operational telemetry required to
+keep the fictional economy healthy. Use these notes alongside the existing `uxAdmin.html` prototype
+when evolving the production-ready admin console.
+
+## Folder Contents
+- `design_document.md` – Deep-dive into the experience architecture, feature pillars, and UX
+  patterns that shape the command center.
+- `feature_catalog.md` – Breakdown of functional modules, intended operators, priority, and key
+  success metrics.
+- `journey_map.md` – Role-based storyboard describing how administrators navigate common
+  maintenance and incident workflows.
+
+Feel free to extend this area with wireframes, component inventories, or motion studies as the
+concept matures.

--- a/design/Frontend/uxAdmin-control-center/design_document.md
+++ b/design/Frontend/uxAdmin-control-center/design_document.md
@@ -1,0 +1,99 @@
+# uxAdmin Command Center Design Document
+
+## 1. Vision
+The uxAdmin command center consolidates every lever VirtualBank staff need to monitor, configure,
+and steer the virtual economy. The interface should feel decisive and calm under pressure, offering
+clear situational awareness, frictionless investigations, and rapid mitigation actions.
+
+## 2. Target Personas
+| Persona | Primary Goals | Interface Needs |
+| --- | --- | --- |
+| **Economy Steward** | Maintain currency health, review market anomalies, tune events. | Macro dashboards, alert routing, scenario controls. |
+| **Support Specialist** | Resolve player issues, process escalations, manage account limits. | Searchable customer profiles, guided flows, audit trails. |
+| **Operations Engineer** | Keep systems performant, trace integration outages. | Real-time telemetry, deployment controls, runbook shortcuts. |
+| **Security Analyst** | Detect fraud attempts, enforce compliance safeguards. | Threat surfaces, policy management, investigation tools. |
+
+## 3. Experience Principles
+1. **Command Readiness** – The home view must surface live health indicators and prioritized tasks.
+2. **Progressive Disclosure** – Reveal advanced tools as context demands to avoid cognitive overload.
+3. **Explainable Actions** – Every control shows impact, prerequisites, and audit linkage before
+   execution.
+4. **Always Recoverable** – Provide undo windows or confirmation gates on every irreversible action.
+
+## 4. Information Architecture
+- **Top Navigation Bar**
+  - Organization switcher, alert inbox, quick actions tray, user profile.
+- **Left Dock**
+  - Primary modules grouped by responsibility: Operations, Economy, Customers, Security, Settings.
+- **Main Canvas**
+  - Tabbed workspaces that retain session context per module.
+- **Right Context Rail**
+  - Inline activity log, assignment panel, related documentation and runbooks.
+
+## 5. Core Modules
+### 5.1 Operations Overview
+- Health grid for middleware, data stores, stock market engines, and scheduled jobs.
+- Incident cards showing severity, impact scope, and time-to-breach SLAs.
+- Live query inspector allowing read-only review of suspicious transactions.
+
+### 5.2 Economy Orchestrator
+- Currency supply and sink analytics with trend comparison toggles.
+- Event scheduler for double-yield weekends, maintenance, or new quest releases.
+- Scenario simulator for testing rule tweaks before production rollout.
+
+### 5.3 Customer Command Desk
+- Unified search that matches on handle, email, or account ID with fuzzy logic.
+- Case timeline showing deposits, trades, support contacts, and risk flags.
+- Action drawer with templated interventions (freeze account, grant credit, reset limits).
+
+### 5.4 Security Watchtower
+- Threat heatmap highlighting anomalous geos, devices, or behaviors.
+- Policy manager with staged rollout and rollback controls.
+- Investigation workspace for tracing multi-account fraud rings.
+
+### 5.5 Configuration & Governance
+- Role management with permission matrices and approval workflow.
+- Feature flag overview with dependency indicators.
+- Audit export center that bundles signed logs for compliance reviews.
+
+## 6. Cross-Cutting Functions
+- **Global Search** for commands, records, and documentation.
+- **Notification Center** with SLA-aware reminders and one-click assignment.
+- **Collaboration Hooks** via comments, mentions, and shareable incident timelines.
+- **Runbook Drawer** pulling markdown guides from the knowledge base.
+
+## 7. Data & Telemetry Strategy
+- Frontend polls lightweight `/status` endpoints for live tiles and uses WebSockets for incident
+  streams to reduce refresh fatigue.
+- State management favors event sourcing snapshots so that back-in-time review is trivial.
+- All charting components support anomaly overlays, thresholds, and drill-through actions.
+
+## 8. Accessibility & Inclusivity
+- Minimum AA contrast across tiles, charts, and text.
+- Keyboard-first interactions: global command palette (`Ctrl/Cmd + K`), focus outlines, skip links.
+- Live region announcements for alerts and streaming updates.
+- Support for reduced motion preferences with subtle transitions.
+
+## 9. Responsive Behavior
+- **Desktop (≥1280px):** Full layout with context rail.
+- **Tablet (768–1279px):** Collapsible left dock, context rail converts to bottom sheet.
+- **Mobile (≤767px):** Prioritize alerting, search, and case interventions through compact cards.
+
+## 10. Security Considerations
+- Session timeouts visualized with countdown and extend controls.
+- Inline secret redaction for sensitive fields by default.
+- Role-based affordances ensure users only see eligible actions and data.
+- Tamper-evident banners when the environment is in sandbox or maintenance mode.
+
+## 11. Implementation Notes
+- Extend existing design tokens for color, spacing, and typography to ensure parity with
+  player-facing experiences.
+- Compose UI in modular panels (`<vb-card>`, `<vb-table>`, `<vb-kpi-tile>`) to reuse across modules.
+- Instrument analytics events (`uxAdmin.module.entered`, `uxAdmin.action.confirmed`) to validate
+  navigation patterns and guardrail adoption.
+
+## 12. Roadmap
+1. Validate navigation taxonomy with current administrator interviews.
+2. Produce low-fidelity wireframes for each module and test flows with clickable prototypes.
+3. Iterate on data-density using real sample telemetry from middleware and stock market services.
+4. Harden compliance features (audit exports, role approvals) before expanding automation controls.

--- a/design/Frontend/uxAdmin-control-center/feature_catalog.md
+++ b/design/Frontend/uxAdmin-control-center/feature_catalog.md
@@ -1,0 +1,16 @@
+# Feature Catalog
+
+| Module | Capability | Operator Persona | Priority | Success Signal |
+| --- | --- | --- | --- | --- |
+| Operations Overview | Live service health tiles with SLA coloring | Operations Engineer | P0 | 100% of critical incidents acknowledged < 2 min |
+| Operations Overview | Incident detail flyout with remediation checklist | Operations Engineer | P0 | Mean time to resolution decreases by 20% |
+| Economy Orchestrator | Supply & sink analytics with scenario comparison | Economy Steward | P0 | Weekly economy review completed in one session |
+| Economy Orchestrator | Event scheduler with approval workflow | Economy Steward | P1 | 95% of events launched with documented approvals |
+| Customer Command Desk | Federated player search and profile merge | Support Specialist | P0 | 90% of support tickets resolved without data request |
+| Customer Command Desk | Action drawer with reversible interventions | Support Specialist | P0 | Zero unauthorized freezes due to guardrails |
+| Security Watchtower | Threat heatmap with anomaly overlays | Security Analyst | P1 | Fraud detection latency reduced to <5 min |
+| Security Watchtower | Investigation graph for linked accounts | Security Analyst | P1 | 75% of fraud cases closed without exporting data |
+| Configuration & Governance | Role matrix editor with simulated access preview | Security Analyst | P1 | No privilege escalation incidents post-launch |
+| Configuration & Governance | Feature flag dependency map | Economy Steward | P2 | Deployments avoid conflicting toggles |
+| Global | Command palette with action search | All | P1 | Task initiation time reduced by 30% |
+| Global | Activity log with export to knowledge base | All | P2 | 90% of incidents tagged with postmortem link |

--- a/design/Frontend/uxAdmin-control-center/index.html
+++ b/design/Frontend/uxAdmin-control-center/index.html
@@ -1,0 +1,399 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>VirtualBank Command Center | Preview</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="../assets/css/styles.css" />
+    <style>
+      body {
+        background: #f7f9fc;
+      }
+      .command-center {
+        display: grid;
+        gap: 2rem;
+        margin: 3rem auto;
+        max-width: 1280px;
+      }
+      .grid-3 {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+        gap: 1.5rem;
+      }
+      .grid-2 {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+        gap: 1.5rem;
+      }
+      .module-header {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        margin-bottom: 1rem;
+      }
+      .module-header h2 {
+        margin: 0;
+      }
+      .pill {
+        display: inline-flex;
+        align-items: center;
+        padding: 0.25rem 0.75rem;
+        border-radius: 999px;
+        font-size: 0.75rem;
+        font-weight: 600;
+        letter-spacing: 0.02em;
+      }
+      .pill.success {
+        background: #e6f6ec;
+        color: #16794b;
+      }
+      .pill.warning {
+        background: #fff4e5;
+        color: #b95000;
+      }
+      .pill.info {
+        background: #e6f0ff;
+        color: #234aa6;
+      }
+      .status-row {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        padding: 0.75rem 0;
+        border-bottom: 1px solid #e4e9f2;
+      }
+      .status-row:last-child {
+        border-bottom: none;
+      }
+      .status-row span {
+        font-weight: 600;
+      }
+      .status-row small {
+        color: #64748b;
+      }
+      .list {
+        margin: 0;
+        padding: 0;
+        list-style: none;
+      }
+      .list li + li {
+        margin-top: 0.75rem;
+      }
+      .list strong {
+        display: block;
+      }
+      .tag-strip {
+        display: flex;
+        gap: 0.5rem;
+        flex-wrap: wrap;
+      }
+      .tag-strip span {
+        padding: 0.35rem 0.7rem;
+        border-radius: 8px;
+        font-size: 0.75rem;
+        background: rgba(35, 74, 166, 0.1);
+        color: #234aa6;
+        font-weight: 600;
+      }
+      .timeline {
+        position: relative;
+        padding-left: 1.5rem;
+      }
+      .timeline::before {
+        content: "";
+        position: absolute;
+        left: 0.45rem;
+        top: 0.5rem;
+        bottom: 0.5rem;
+        width: 2px;
+        background: linear-gradient(180deg, rgba(35, 74, 166, 0.4), rgba(35, 74, 166, 0));
+      }
+      .timeline-item {
+        position: relative;
+        padding: 0.5rem 0 0.5rem 0.5rem;
+      }
+      .timeline-item::before {
+        content: "";
+        position: absolute;
+        left: -1.05rem;
+        top: 0.9rem;
+        width: 10px;
+        height: 10px;
+        border-radius: 50%;
+        background: #234aa6;
+      }
+      .timeline-item strong {
+        display: block;
+        margin-bottom: 0.15rem;
+      }
+      .table {
+        width: 100%;
+        border-collapse: collapse;
+      }
+      .table th,
+      .table td {
+        text-align: left;
+        padding: 0.75rem;
+        border-bottom: 1px solid #e4e9f2;
+      }
+      .table th {
+        color: #64748b;
+        font-weight: 600;
+        font-size: 0.75rem;
+        letter-spacing: 0.05em;
+        text-transform: uppercase;
+      }
+      @media (max-width: 768px) {
+        nav {
+          flex-direction: column;
+          gap: 1.5rem;
+          align-items: flex-start;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <nav>
+      <div class="brand">
+        VirtualBank <span>Command Center</span>
+      </div>
+      <div class="actions">
+        <a class="btn-ghost" href="../uxAdmin.html">Return to staff login</a>
+        <a class="btn-secondary" href="../index.html">Customer experience</a>
+      </div>
+    </nav>
+
+    <main>
+      <section class="shell card card-muted" style="margin-top: 2rem;">
+        <span class="tag">Preview concept</span>
+        <h1>Operational command center for VirtualBank game masters</h1>
+        <p>
+          This prototype illustrates how administrators monitor platform health, resolve escalations, and coordinate live events.
+          Each module is designed for swift triage, clear accountability, and a delightful workday rhythm.
+        </p>
+        <div class="tag-strip" style="margin-top: 1.5rem;">
+          <span>Realtime oversight</span>
+          <span>Queue automation</span>
+          <span>Event orchestration</span>
+          <span>Audit-ready</span>
+        </div>
+      </section>
+
+      <section class="command-center">
+        <div class="grid-3">
+          <article class="card">
+            <div class="module-header">
+              <h2>Platform status</h2>
+              <span class="pill success">Operational</span>
+            </div>
+            <div class="status-row">
+              <div>
+                <span>Login API</span>
+                <small>Avg latency 142ms</small>
+              </div>
+              <small>99.98% uptime</small>
+            </div>
+            <div class="status-row">
+              <div>
+                <span>Payments gateway</span>
+                <small>Ledger sync nominal</small>
+              </div>
+              <small>99.94% uptime</small>
+            </div>
+            <div class="status-row">
+              <div>
+                <span>Market desk</span>
+                <small>Next volatility sweep in 12m</small>
+              </div>
+              <small>99.88% uptime</small>
+            </div>
+          </article>
+
+          <article class="card">
+            <div class="module-header">
+              <h2>Active shifts</h2>
+              <span class="pill info">Crew of 4</span>
+            </div>
+            <ul class="list">
+              <li>
+                <strong>Celeste Ray • Command</strong>
+                Coordinating feature flags, reviewing major incidents, and approving escalations.
+              </li>
+              <li>
+                <strong>Leo Amari • Economy</strong>
+                Monitoring credit yields, treasury liquidity, and market drift alerts.
+              </li>
+              <li>
+                <strong>Mira Chen • Support</strong>
+                Handling escalated tickets, coaching mentors, and scanning sentiment feeds.
+              </li>
+            </ul>
+          </article>
+
+          <article class="card">
+            <div class="module-header">
+              <h2>Runbook shortcuts</h2>
+              <span class="pill warning">Critical ready</span>
+            </div>
+            <ul class="list">
+              <li>
+                <strong>Major incident bridge</strong>
+                Spin up comms hub, pin leadership contacts, and load restoration checklist in one click.
+              </li>
+              <li>
+                <strong>Economy rebalance</strong>
+                Draft patch notes, queue automated grants, and schedule broadcast to all players.
+              </li>
+              <li>
+                <strong>Security drill</strong>
+                Trigger red-team scenario with sandboxed alerts to validate staff response time.
+              </li>
+            </ul>
+          </article>
+        </div>
+
+        <div class="grid-2">
+          <article class="card">
+            <div class="module-header">
+              <h2>Escalation queue</h2>
+              <span class="pill warning">6 awaiting</span>
+            </div>
+            <table class="table">
+              <thead>
+                <tr>
+                  <th>Priority</th>
+                  <th>Topic</th>
+                  <th>Owner</th>
+                  <th>SLA</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td><span class="pill warning">P1</span></td>
+                  <td>Transfer delays in EU cluster</td>
+                  <td>Celeste Ray</td>
+                  <td>12m remaining</td>
+                </tr>
+                <tr>
+                  <td><span class="pill info">P2</span></td>
+                  <td>Mentor onboarding stuck at step 3</td>
+                  <td>Mira Chen</td>
+                  <td>29m remaining</td>
+                </tr>
+                <tr>
+                  <td><span class="pill info">P2</span></td>
+                  <td>Promo vault miscredit</td>
+                  <td>Leo Amari</td>
+                  <td>51m remaining</td>
+                </tr>
+                <tr>
+                  <td><span class="pill info">P3</span></td>
+                  <td>UX copy review request</td>
+                  <td>Nova Ellis</td>
+                  <td>2h 15m</td>
+                </tr>
+              </tbody>
+            </table>
+          </article>
+
+          <article class="card">
+            <div class="module-header">
+              <h2>Live comms</h2>
+              <span class="pill info">Broadcast</span>
+            </div>
+            <div class="timeline">
+              <div class="timeline-item">
+                <strong>14:05 • Outage drill wrap-up</strong>
+                Command staff signed off runbook steps; publishing recap to knowledge base.
+              </div>
+              <div class="timeline-item">
+                <strong>13:42 • Mentor huddle</strong>
+                Support lead flagged 4 rising sentiment spikes; action items assigned.
+              </div>
+              <div class="timeline-item">
+                <strong>13:08 • Market bulletin</strong>
+                Economy desk announced volatility cap for Sector R for next 6 hours.
+              </div>
+              <div class="timeline-item">
+                <strong>12:50 • Feature flag</strong>
+                Command toggled "Quest Vault" beta live for cohort GAMMA-42.
+              </div>
+            </div>
+          </article>
+        </div>
+
+        <div class="grid-2">
+          <article class="card">
+            <div class="module-header">
+              <h2>Health signals</h2>
+              <span class="pill success">Stable trend</span>
+            </div>
+            <table class="table">
+              <thead>
+                <tr>
+                  <th>Metric</th>
+                  <th>Current</th>
+                  <th>Change</th>
+                  <th>Target</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>Active players</td>
+                  <td>42,178</td>
+                  <td><span class="pill success">▲ 4.2%</span></td>
+                  <td>40,000</td>
+                </tr>
+                <tr>
+                  <td>Support backlog</td>
+                  <td>38 tickets</td>
+                  <td><span class="pill success">▼ 12%</span></td>
+                  <td>&lt;45</td>
+                </tr>
+                <tr>
+                  <td>Fraud flags</td>
+                  <td>3 cases</td>
+                  <td><span class="pill warning">▲ 1</span></td>
+                  <td>&lt;2</td>
+                </tr>
+                <tr>
+                  <td>Capital reserves</td>
+                  <td>231.5M credits</td>
+                  <td><span class="pill success">▲ 2.1%</span></td>
+                  <td>200M</td>
+                </tr>
+              </tbody>
+            </table>
+          </article>
+
+          <article class="card">
+            <div class="module-header">
+              <h2>Upcoming rituals</h2>
+              <span class="pill info">Next 24h</span>
+            </div>
+            <ul class="list">
+              <li>
+                <strong>17:00 • Seasonal quest kickoff</strong>
+                Launch hero narrative and distribute golden ticket invites to top 5% explorers.
+              </li>
+              <li>
+                <strong>19:30 • Treasury rebalance</strong>
+                Sync vault reserves with market desk, update liquidity ratios, and publish digest.
+              </li>
+              <li>
+                <strong>08:00 • Mentor coaching</strong>
+                Host skill sprint on empathetic outreach with real-time chat shadowing.
+              </li>
+            </ul>
+          </article>
+        </div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/design/Frontend/uxAdmin-control-center/journey_map.md
+++ b/design/Frontend/uxAdmin-control-center/journey_map.md
@@ -1,0 +1,40 @@
+# Administrator Journey Map
+
+## Scenario A – Respond to Middleware Incident
+1. **Alert Intake**
+   - Operations Overview raises a critical alert with SLA countdown and suggested assignee.
+   - Operator uses quick action to claim the incident and auto-notify collaborators.
+2. **Root Cause Investigation**
+   - Live telemetry stream highlights spike on transaction queue length.
+   - Runbook drawer surfaces "Middleware Queue Drain" checklist; operator reviews logs in context rail.
+3. **Mitigation**
+   - Operator triggers safe-mode toggle for affected service, then launches backlog drain script from quick actions.
+   - Confirmation modal outlines affected modules and rollback plan.
+4. **Recovery & Debrief**
+   - KPI tiles return to green; operator logs summary in activity feed and attaches postmortem template.
+
+## Scenario B – Resolve Player Escalation
+1. **Case Discovery**
+   - Support Specialist receives notification tagged "Player Funds Missing".
+   - Uses global search to locate player by handle and opens Customer Command Desk workspace.
+2. **Investigation**
+   - Timeline reveals delayed stock settlement and automated limit freeze.
+   - Specialist opens linked market order to verify reconciliation status.
+3. **Action**
+   - From action drawer, specialist applies "Lift Freeze" with 24-hour review reminder.
+   - System generates audit entry and notifies Economy Steward of temporary override.
+4. **Follow-Up**
+   - Specialist attaches response template to player message center and schedules check-in reminder.
+
+## Scenario C – Launch Double-Yield Weekend
+1. **Planning**
+   - Economy Steward reviews supply & sink analytics to confirm stability window.
+   - Creates draft event in Economy Orchestrator with scoped dates and affected sectors.
+2. **Approval**
+   - Submits event for governance approval; Security Analyst reviews risk flags and adds conditional guardrails.
+3. **Execution**
+   - Upon approval, steward activates event; feature flag dependency map confirms no conflicts.
+   - Notification center posts countdown for operations and support teams.
+4. **Post-Event Review**
+   - Analytics snapshot auto-generated and shared to knowledge base.
+   - Steward records learnings and updates scenario presets for next iteration.


### PR DESCRIPTION
## Summary
- add an admin command center HTML prototype that mirrors the uxAdmin control center concept workspace
- surface the new preview entry point in the repository README for quick discovery
- log the documentation and preview addition in the changelog with change type, reason, and summary

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d574c26c788333935e7723a7934c11