### PR TITLE
Expand fake company dataset for pre-seed scenarios

### DIFF
--- a/Changelog/Changelog.md
+++ b/Changelog/Changelog.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [2025-10-07] Market Dataset Enrichment
+- **Change Type:** Normal Change
+- **Reason:** Pre-seed planning requires a richer fake market so investors can experience diverse scenarios.
+- **What Changed:** Expanded `dataset/fake_companies.json` to 100 curated fictional firms, refreshed the README dataset summary, and documented the update here.
+
 -# [2025-10-06] uxAdmin Command Center Preview
 - **Change Type:** Normal Change
 - **Reason:** Provide a tangible HTML preview so stakeholders can experience the proposed administrator control center flow.

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ VirtualBank is a playful online banking simulator that lets users explore modern
 ## Datasets
 The `dataset` folder contains ready-to-use JSON files for stock-market prototyping:
 
-- `fake_companies.json` lists sector-diverse fictional firms with baseline pricing and volatility hints.
+- `fake_companies.json` lists roughly one hundred sector-diverse fictional firms with baseline pricing and volatility hints.
 - `sample_portfolios.json` provides example allocations that feature different strategies and risk profiles.
 
 These assets let designers and engineers populate market simulations instantly without crafting data from scratch.

--- a/dataset/fake_companies.json
+++ b/dataset/fake_companies.json
@@ -1,5 +1,85 @@
 [
   {
+    "ticker": "ACI",
+    "name": "Glacier Ventures",
+    "sector": "Robotics",
+    "region": "South America",
+    "market_cap_millions": 3506,
+    "base_price": 42.56,
+    "volatility": 0.12,
+    "story": "Open-source ecosystem delivering immersive engagement for digital citizens."
+  },
+  {
+    "ticker": "AER",
+    "name": "Aero Supply",
+    "sector": "Agile Manufacturing",
+    "region": "Oceania",
+    "market_cap_millions": 1369,
+    "base_price": 24.77,
+    "volatility": 0.18,
+    "story": "Quantum-enhanced ecosystem delivering resilient performance for creator guilds."
+  },
+  {
+    "ticker": "ALM",
+    "name": "Coral Materials",
+    "sector": "Supply Chain",
+    "region": "Middle East",
+    "market_cap_millions": 3847,
+    "base_price": 170.4,
+    "volatility": 0.25,
+    "story": "Machine-learning-guided operations hub delivering hyperlocal outcomes for urban planners."
+  },
+  {
+    "ticker": "ALS",
+    "name": "Coral Solutions",
+    "sector": "Robotics",
+    "region": "South America",
+    "market_cap_millions": 2775,
+    "base_price": 68.75,
+    "volatility": 0.35,
+    "story": "Edge-optimized ecosystem delivering scalable growth for next-gen merchants."
+  },
+  {
+    "ticker": "ANT",
+    "name": "Quanta Security",
+    "sector": "Sustainable Fashion",
+    "region": "Middle East",
+    "market_cap_millions": 863,
+    "base_price": 30.66,
+    "volatility": 0.23,
+    "story": "Cloud-native toolkit delivering adaptive planning for talent collectives."
+  },
+  {
+    "ticker": "ARR",
+    "name": "Quarry Capital",
+    "sector": "Marine Technology",
+    "region": "Latin America",
+    "market_cap_millions": 3879,
+    "base_price": 175.62,
+    "volatility": 0.31,
+    "story": "Sensor-driven ecosystem delivering scalable growth for cooperative lenders."
+  },
+  {
+    "ticker": "ATL",
+    "name": "Atlas Wearables",
+    "sector": "Sustainable Fashion",
+    "region": "North America",
+    "market_cap_millions": 5266,
+    "base_price": 76.21,
+    "volatility": 0.12,
+    "story": "Gamified marketplace delivering collaborative intelligence for cooperative lenders."
+  },
+  {
+    "ticker": "ATT",
+    "name": "Lattice Recycling",
+    "sector": "Information Technology",
+    "region": "Oceania",
+    "market_cap_millions": 1221,
+    "base_price": 82.72,
+    "volatility": 0.27,
+    "story": "Human-centered infrastructure delivering immersive engagement for next-gen merchants."
+  },
+  {
     "ticker": "AVX",
     "name": "Aventix Labs",
     "sector": "Biotech",
@@ -8,6 +88,36 @@
     "base_price": 42.15,
     "volatility": 0.27,
     "story": "Clinical-stage biotech focused on adaptive antiviral therapies for virtual pandemics."
+  },
+  {
+    "ticker": "BER",
+    "name": "Ember Wellness",
+    "sector": "Energy Storage",
+    "region": "Asia-Pacific",
+    "market_cap_millions": 970,
+    "base_price": 54.79,
+    "volatility": 0.34,
+    "story": "Carbon-negative service grid delivering collaborative intelligence for sustainability stewards."
+  },
+  {
+    "ticker": "BIO",
+    "name": "Bionic Solutions",
+    "sector": "Energy Storage",
+    "region": "Oceania",
+    "market_cap_millions": 3121,
+    "base_price": 123.62,
+    "volatility": 0.15,
+    "story": "Bioadaptive experience layer delivering immersive engagement for cooperative lenders."
+  },
+  {
+    "ticker": "BOR",
+    "name": "Boreal Security",
+    "sector": "Energy Storage",
+    "region": "Global",
+    "market_cap_millions": 6037,
+    "base_price": 157.23,
+    "volatility": 0.33,
+    "story": "Quantum-enhanced ecosystem delivering hyperlocal outcomes for cooperative lenders."
   },
   {
     "ticker": "BQE",
@@ -20,6 +130,36 @@
     "story": "Utility-scale floating solar arrays powering coastal smart cities across the simulation."
   },
   {
+    "ticker": "BSI",
+    "name": "Obsidian Insights",
+    "sector": "Digital Identity",
+    "region": "South America",
+    "market_cap_millions": 6158,
+    "base_price": 66.82,
+    "volatility": 0.32,
+    "story": "Community-owned product line delivering real-time insights for virtual health teams."
+  },
+  {
+    "ticker": "CIN",
+    "name": "Cinder Foods",
+    "sector": "Media & Gaming",
+    "region": "South America",
+    "market_cap_millions": 2455,
+    "base_price": 97.15,
+    "volatility": 0.13,
+    "story": "Autonomous experience layer delivering collaborative intelligence for next-gen merchants."
+  },
+  {
+    "ticker": "COR",
+    "name": "Coral Apparel",
+    "sector": "E-commerce",
+    "region": "North America",
+    "market_cap_millions": 1857,
+    "base_price": 129.44,
+    "volatility": 0.21,
+    "story": "Immersive product line delivering resilient performance for creator guilds."
+  },
+  {
     "ticker": "CRN",
     "name": "Chronicle Networks",
     "sector": "Information Technology",
@@ -28,6 +168,36 @@
     "base_price": 115.33,
     "volatility": 0.32,
     "story": "Latency-free quantum mesh routers connecting gamer guilds and financial hubs."
+  },
+  {
+    "ticker": "DEL",
+    "name": "Delta Hospitality",
+    "sector": "Energy Storage",
+    "region": "Europe",
+    "market_cap_millions": 2586,
+    "base_price": 44.59,
+    "volatility": 0.26,
+    "story": "Immersive toolkit delivering scalable growth for metaverse travelers."
+  },
+  {
+    "ticker": "DIG",
+    "name": "Indigo Launch",
+    "sector": "Healthcare",
+    "region": "Middle East",
+    "market_cap_millions": 1715,
+    "base_price": 24.46,
+    "volatility": 0.16,
+    "story": "Bioadaptive analytics suite delivering adaptive planning for metaverse travelers."
+  },
+  {
+    "ticker": "DRI",
+    "name": "Drift Learning",
+    "sector": "Consumer Staples",
+    "region": "Nordics",
+    "market_cap_millions": 5058,
+    "base_price": 28.9,
+    "volatility": 0.29,
+    "story": "Open-source platform delivering hyperlocal outcomes for next-gen merchants."
   },
   {
     "ticker": "DYN",
@@ -40,6 +210,26 @@
     "story": "Autonomous freight pods coordinating real-time supply chains for virtual retailers."
   },
   {
+    "ticker": "EAL",
+    "name": "Boreal Manufacturing",
+    "sector": "Healthcare",
+    "region": "South America",
+    "market_cap_millions": 1584,
+    "base_price": 91.82,
+    "volatility": 0.15,
+    "story": "Autonomous operations hub delivering immersive engagement for virtual health teams."
+  },
+  {
+    "ticker": "ECH",
+    "name": "Echo Transit",
+    "sector": "Logistics",
+    "region": "Asia-Pacific",
+    "market_cap_millions": 1772,
+    "base_price": 148.37,
+    "volatility": 0.37,
+    "story": "Edge-optimized product line delivering hyperlocal outcomes for talent collectives."
+  },
+  {
     "ticker": "ELM",
     "name": "Elm Grove Foods",
     "sector": "Consumer Staples",
@@ -48,6 +238,86 @@
     "base_price": 24.68,
     "volatility": 0.15,
     "story": "Vertical farm collectives supplying nutrient-rich produce to megacities."
+  },
+  {
+    "ticker": "ELT",
+    "name": "Delta Identity",
+    "sector": "Robotics",
+    "region": "Asia-Pacific",
+    "market_cap_millions": 5775,
+    "base_price": 157.97,
+    "volatility": 0.25,
+    "story": "AI-orchestrated analytics suite delivering immersive engagement for sustainability stewards."
+  },
+  {
+    "ticker": "EMB",
+    "name": "Ember Purification",
+    "sector": "Fintech",
+    "region": "Europe",
+    "market_cap_millions": 1344,
+    "base_price": 122.88,
+    "volatility": 0.21,
+    "story": "Predictive operations hub delivering real-time insights for creator guilds."
+  },
+  {
+    "ticker": "ENI",
+    "name": "Zenith Storage",
+    "sector": "E-commerce",
+    "region": "Europe",
+    "market_cap_millions": 2836,
+    "base_price": 71.32,
+    "volatility": 0.25,
+    "story": "Open-source infrastructure delivering real-time insights for creator guilds."
+  },
+  {
+    "ticker": "ERI",
+    "name": "Meridian Harvest",
+    "sector": "Energy Storage",
+    "region": "South America",
+    "market_cap_millions": 6181,
+    "base_price": 118.73,
+    "volatility": 0.19,
+    "story": "Machine-learning-guided marketplace delivering real-time insights for creator guilds."
+  },
+  {
+    "ticker": "ERO",
+    "name": "Aero Fabrication",
+    "sector": "VR/AR",
+    "region": "Nordics",
+    "market_cap_millions": 3935,
+    "base_price": 21.58,
+    "volatility": 0.25,
+    "story": "Regenerative operations hub delivering seamless orchestration for digital citizens."
+  },
+  {
+    "ticker": "ERT",
+    "name": "Vertex Identity",
+    "sector": "Energy Storage",
+    "region": "Africa",
+    "market_cap_millions": 4267,
+    "base_price": 57.88,
+    "volatility": 0.19,
+    "story": "Carbon-negative product line delivering resilient performance for creator guilds."
+  },
+  {
+    "ticker": "ETI",
+    "name": "Kinetic Learning",
+    "sector": "Cybersecurity",
+    "region": "Latin America",
+    "market_cap_millions": 1164,
+    "base_price": 38.72,
+    "volatility": 0.23,
+    "story": "Regenerative operations hub delivering immersive engagement for digital citizens."
+  },
+  {
+    "ticker": "EYS",
+    "name": "Keystone Fabrication",
+    "sector": "Renewable Energy",
+    "region": "Europe",
+    "market_cap_millions": 5815,
+    "base_price": 84.29,
+    "volatility": 0.35,
+    "story": "Data-rich platform delivering immersive engagement for cooperative lenders."
   },
   {
     "ticker": "FLR",
@@ -60,6 +330,26 @@
     "story": "Immersive holo-arenas broadcasting esports and narrative-driven interactive dramas."
   },
   {
+    "ticker": "FLU",
+    "name": "Flux Wearables",
+    "sector": "Financial Services",
+    "region": "Africa",
+    "market_cap_millions": 3367,
+    "base_price": 113.62,
+    "volatility": 0.33,
+    "story": "Cyber-resilient experience layer delivering hyperlocal outcomes for cooperative lenders."
+  },
+  {
+    "ticker": "FOR",
+    "name": "Forge Hospitality",
+    "sector": "EdTech",
+    "region": "Asia-Pacific",
+    "market_cap_millions": 5924,
+    "base_price": 127.68,
+    "volatility": 0.35,
+    "story": "Carbon-negative toolkit delivering trustworthy automation for smart-city operators."
+  },
+  {
     "ticker": "GHC",
     "name": "GreenHorizon Capital",
     "sector": "Financial Services",
@@ -70,6 +360,36 @@
     "story": "Impact-focused investment firm underwriting sustainability ventures in-game."
   },
   {
+    "ticker": "GLA",
+    "name": "Glacier Bioware",
+    "sector": "AI Services",
+    "region": "Latin America",
+    "market_cap_millions": 5538,
+    "base_price": 45.82,
+    "volatility": 0.22,
+    "story": "Data-rich experience layer delivering ethical innovation for digital citizens."
+  },
+  {
+    "ticker": "GLY",
+    "name": "Glyph Studios",
+    "sector": "Cybersecurity",
+    "region": "Europe",
+    "market_cap_millions": 5424,
+    "base_price": 23.88,
+    "volatility": 0.34,
+    "story": "Modular service grid delivering adaptive planning for next-gen merchants."
+  },
+  {
+    "ticker": "HEL",
+    "name": "Helio Wearables",
+    "sector": "Smart Mobility",
+    "region": "South America",
+    "market_cap_millions": 2636,
+    "base_price": 19.93,
+    "volatility": 0.23,
+    "story": "Human-centered experience layer delivering trustworthy automation for virtual health teams."
+  },
+  {
     "ticker": "HYS",
     "name": "HydraSynth Materials",
     "sector": "Advanced Materials",
@@ -78,6 +398,66 @@
     "base_price": 88.05,
     "volatility": 0.29,
     "story": "Programmable composites enabling adaptive architecture and vehicles."
+  },
+  {
+    "ticker": "IDA",
+    "name": "Tidal Hospitality",
+    "sector": "Digital Identity",
+    "region": "North America",
+    "market_cap_millions": 3039,
+    "base_price": 60.56,
+    "volatility": 0.23,
+    "story": "Circular analytics suite delivering resilient performance for sustainability stewards."
+  },
+  {
+    "ticker": "IEL",
+    "name": "Yield Insights",
+    "sector": "Healthcare",
+    "region": "South America",
+    "market_cap_millions": 1076,
+    "base_price": 81.99,
+    "volatility": 0.21,
+    "story": "Cyber-resilient toolkit delivering real-time insights for next-gen merchants."
+  },
+  {
+    "ticker": "IFT",
+    "name": "Drift Vehicles",
+    "sector": "Sustainable Fashion",
+    "region": "Middle East",
+    "market_cap_millions": 3190,
+    "base_price": 155.16,
+    "volatility": 0.34,
+    "story": "Edge-optimized marketplace delivering seamless orchestration for next-gen merchants."
+  },
+  {
+    "ticker": "ILL",
+    "name": "Willow Purification",
+    "sector": "Circular Economy",
+    "region": "Oceania",
+    "market_cap_millions": 5616,
+    "base_price": 50.3,
+    "volatility": 0.26,
+    "story": "Cyber-resilient operations hub delivering immersive engagement for urban planners."
+  },
+  {
+    "ticker": "IND",
+    "name": "Cinder Insurance",
+    "sector": "Space Systems",
+    "region": "South America",
+    "market_cap_millions": 4320,
+    "base_price": 71.07,
+    "volatility": 0.33,
+    "story": "Sensor-driven product line delivering real-time insights for next-gen merchants."
+  },
+  {
+    "ticker": "INE",
+    "name": "Kinetic Purification",
+    "sector": "Climate Analytics",
+    "region": "Nordics",
+    "market_cap_millions": 2301,
+    "base_price": 157.33,
+    "volatility": 0.35,
+    "story": "Data-rich toolkit delivering real-time insights for cooperative lenders."
   },
   {
     "ticker": "ION",
@@ -100,6 +480,36 @@
     "story": "Story-forward interactive cinema fusing live performers with AI companions."
   },
   {
+    "ticker": "JUN",
+    "name": "Juniper Recycling",
+    "sector": "Green Construction",
+    "region": "Nordics",
+    "market_cap_millions": 5568,
+    "base_price": 149.01,
+    "volatility": 0.35,
+    "story": "Predictive experience layer delivering seamless orchestration for smart-city operators."
+  },
+  {
+    "ticker": "KEY",
+    "name": "Keystone Studios",
+    "sector": "Media & Gaming",
+    "region": "Nordics",
+    "market_cap_millions": 1116,
+    "base_price": 176.31,
+    "volatility": 0.26,
+    "story": "Immersive ecosystem delivering seamless orchestration for talent collectives."
+  },
+  {
+    "ticker": "KIN",
+    "name": "Kinetic Structures",
+    "sector": "Smart Homes",
+    "region": "Oceania",
+    "market_cap_millions": 4016,
+    "base_price": 174.03,
+    "volatility": 0.36,
+    "story": "Autonomous marketplace delivering collaborative intelligence for virtual health teams."
+  },
+  {
     "ticker": "KRS",
     "name": "Kerasan Health",
     "sector": "Healthcare",
@@ -110,6 +520,36 @@
     "story": "Telehealth cooperative offering personalized care navigation in the metaverse."
   },
   {
+    "ticker": "LAC",
+    "name": "Glacier Vehicles",
+    "sector": "Quantum Computing",
+    "region": "Nordics",
+    "market_cap_millions": 1803,
+    "base_price": 85.44,
+    "volatility": 0.31,
+    "story": "Quantum-enhanced analytics suite delivering ethical innovation for sustainability stewards."
+  },
+  {
+    "ticker": "LAT",
+    "name": "Lattice Renewables",
+    "sector": "VR/AR",
+    "region": "North America",
+    "market_cap_millions": 3119,
+    "base_price": 22.08,
+    "volatility": 0.27,
+    "story": "Human-centered experience layer delivering scalable growth for digital citizens."
+  },
+  {
+    "ticker": "LLO",
+    "name": "Willow Synthetics",
+    "sector": "Cybersecurity",
+    "region": "Nordics",
+    "market_cap_millions": 4801,
+    "base_price": 121.63,
+    "volatility": 0.36,
+    "story": "Data-rich analytics suite delivering collaborative intelligence for sustainability stewards."
+  },
+  {
     "ticker": "LUM",
     "name": "LumenForge Systems",
     "sector": "Industrial Tech",
@@ -118,5 +558,445 @@
     "base_price": 97.65,
     "volatility": 0.28,
     "story": "Photon-powered fabrication plants producing modular infrastructure kits."
+  },
+  {
+    "ticker": "LUX",
+    "name": "Flux Identity",
+    "sector": "Robotics",
+    "region": "Oceania",
+    "market_cap_millions": 3512,
+    "base_price": 109.21,
+    "volatility": 0.3,
+    "story": "Community-owned product line delivering immersive engagement for creator guilds."
+  },
+  {
+    "ticker": "MBE",
+    "name": "Umber Harvest",
+    "sector": "Supply Chain",
+    "region": "Africa",
+    "market_cap_millions": 3314,
+    "base_price": 140.01,
+    "volatility": 0.22,
+    "story": "Predictive marketplace delivering hyperlocal outcomes for sustainability stewards."
+  },
+  {
+    "ticker": "MER",
+    "name": "Meridian Builders",
+    "sector": "Climate Analytics",
+    "region": "North America",
+    "market_cap_millions": 1466,
+    "base_price": 168.12,
+    "volatility": 0.35,
+    "story": "Bioadaptive product line delivering real-time insights for next-gen merchants."
+  },
+  {
+    "ticker": "NDE",
+    "name": "Cinder Vehicles",
+    "sector": "Green Construction",
+    "region": "Oceania",
+    "market_cap_millions": 2601,
+    "base_price": 16.83,
+    "volatility": 0.18,
+    "story": "Circular analytics suite delivering real-time insights for metaverse travelers."
+  },
+  {
+    "ticker": "NDI",
+    "name": "Indigo Renewables",
+    "sector": "VR/AR",
+    "region": "Oceania",
+    "market_cap_millions": 2356,
+    "base_price": 94.28,
+    "volatility": 0.19,
+    "story": "Machine-learning-guided platform delivering collaborative intelligence for virtual health teams."
+  },
+  {
+    "ticker": "NET",
+    "name": "Kinetic Recycling",
+    "sector": "Circular Economy",
+    "region": "Europe",
+    "market_cap_millions": 1891,
+    "base_price": 174.09,
+    "volatility": 0.15,
+    "story": "AI-orchestrated marketplace delivering adaptive planning for cooperative lenders."
+  },
+  {
+    "ticker": "NIM",
+    "name": "Nimbus Commerce",
+    "sector": "Digital Identity",
+    "region": "Asia-Pacific",
+    "market_cap_millions": 2909,
+    "base_price": 85.88,
+    "volatility": 0.3,
+    "story": "Carbon-negative platform delivering adaptive planning for next-gen merchants."
+  },
+  {
+    "ticker": "NIT",
+    "name": "Zenith Environments",
+    "sector": "Fintech",
+    "region": "Europe",
+    "market_cap_millions": 5400,
+    "base_price": 128.18,
+    "volatility": 0.28,
+    "story": "Carbon-negative marketplace delivering adaptive planning for creator guilds."
+  },
+  {
+    "ticker": "OBS",
+    "name": "Obsidian Materials",
+    "sector": "Renewable Energy",
+    "region": "Middle East",
+    "market_cap_millions": 2556,
+    "base_price": 49.89,
+    "volatility": 0.31,
+    "story": "Open-source service grid delivering adaptive planning for cooperative lenders."
+  },
+  {
+    "ticker": "OLA",
+    "name": "Solar Fabrication",
+    "sector": "Hospitality & Travel",
+    "region": "Latin America",
+    "market_cap_millions": 850,
+    "base_price": 88.68,
+    "volatility": 0.2,
+    "story": "Cloud-native service grid delivering collaborative intelligence for talent collectives."
+  },
+  {
+    "ticker": "ONC",
+    "name": "Ion Cuisine",
+    "sector": "Climate Analytics",
+    "region": "Europe",
+    "market_cap_millions": 935,
+    "base_price": 156.73,
+    "volatility": 0.16,
+    "story": "Data-rich toolkit delivering adaptive planning for creator guilds."
+  },
+  {
+    "ticker": "ONI",
+    "name": "Bionic Intelligence",
+    "sector": "Smart Mobility",
+    "region": "Oceania",
+    "market_cap_millions": 1043,
+    "base_price": 114.61,
+    "volatility": 0.31,
+    "story": "Autonomous product line delivering immersive engagement for creator guilds."
+  },
+  {
+    "ticker": "ONR",
+    "name": "Orion Robotics",
+    "sector": "Robotics",
+    "region": "Nordics",
+    "market_cap_millions": 1133,
+    "base_price": 127.64,
+    "volatility": 0.36,
+    "story": "Circular product line delivering collaborative intelligence for creator guilds."
+  },
+  {
+    "ticker": "ORA",
+    "name": "Coral Homes",
+    "sector": "Digital Wellness",
+    "region": "Europe",
+    "market_cap_millions": 2580,
+    "base_price": 50.14,
+    "volatility": 0.21,
+    "story": "Circular experience layer delivering trustworthy automation for urban planners."
+  },
+  {
+    "ticker": "ORE",
+    "name": "Boreal Networks",
+    "sector": "EdTech",
+    "region": "Nordics",
+    "market_cap_millions": 5557,
+    "base_price": 154.83,
+    "volatility": 0.14,
+    "story": "Predictive analytics suite delivering trustworthy automation for cooperative lenders."
+  },
+  {
+    "ticker": "ORI",
+    "name": "Orion Capital",
+    "sector": "Wearables",
+    "region": "Middle East",
+    "market_cap_millions": 4264,
+    "base_price": 118.98,
+    "volatility": 0.21,
+    "story": "Gamified infrastructure delivering trustworthy automation for metaverse travelers."
+  },
+  {
+    "ticker": "PUL",
+    "name": "Pulse Quantum",
+    "sector": "Robotics",
+    "region": "Asia-Pacific",
+    "market_cap_millions": 4139,
+    "base_price": 152.15,
+    "volatility": 0.3,
+    "story": "Regenerative experience layer delivering real-time insights for talent collectives."
+  },
+  {
+    "ticker": "QUA",
+    "name": "Quanta Mobility",
+    "sector": "EdTech",
+    "region": "Latin America",
+    "market_cap_millions": 4965,
+    "base_price": 56.51,
+    "volatility": 0.27,
+    "story": "Circular toolkit delivering resilient performance for next-gen merchants."
+  },
+  {
+    "ticker": "RAL",
+    "name": "Coral Wellness",
+    "sector": "Agriculture Tech",
+    "region": "Latin America",
+    "market_cap_millions": 4426,
+    "base_price": 145.45,
+    "volatility": 0.37,
+    "story": "Data-rich service grid delivering immersive engagement for talent collectives."
+  },
+  {
+    "ticker": "REA",
+    "name": "Boreal Renewables",
+    "sector": "VR/AR",
+    "region": "North America",
+    "market_cap_millions": 3416,
+    "base_price": 50.06,
+    "volatility": 0.14,
+    "story": "Community-owned platform delivering trustworthy automation for next-gen merchants."
+  },
+  {
+    "ticker": "RIF",
+    "name": "Rift Fabrication",
+    "sector": "Climate Analytics",
+    "region": "South America",
+    "market_cap_millions": 4967,
+    "base_price": 34.66,
+    "volatility": 0.36,
+    "story": "Circular analytics suite delivering seamless orchestration for next-gen merchants."
+  },
+  {
+    "ticker": "RIO",
+    "name": "Orion Dynamics",
+    "sector": "Consumer Staples",
+    "region": "North America",
+    "market_cap_millions": 2425,
+    "base_price": 23.79,
+    "volatility": 0.13,
+    "story": "Cloud-native service grid delivering ethical innovation for next-gen merchants."
+  },
+  {
+    "ticker": "RRY",
+    "name": "Quarry Bioware",
+    "sector": "Agile Manufacturing",
+    "region": "Africa",
+    "market_cap_millions": 1315,
+    "base_price": 149.59,
+    "volatility": 0.32,
+    "story": "Bioadaptive product line delivering trustworthy automation for smart-city operators."
+  },
+  {
+    "ticker": "RTE",
+    "name": "Vertex Reality",
+    "sector": "Cybersecurity",
+    "region": "South America",
+    "market_cap_millions": 2322,
+    "base_price": 136.22,
+    "volatility": 0.19,
+    "story": "Circular experience layer delivering adaptive planning for metaverse travelers."
+  },
+  {
+    "ticker": "RYA",
+    "name": "Quarry Agritech",
+    "sector": "Hospitality & Travel",
+    "region": "Asia-Pacific",
+    "market_cap_millions": 4378,
+    "base_price": 166.52,
+    "volatility": 0.37,
+    "story": "Open-source platform delivering collaborative intelligence for urban planners."
+  },
+  {
+    "ticker": "SID",
+    "name": "Obsidian Vehicles",
+    "sector": "E-commerce",
+    "region": "North America",
+    "market_cap_millions": 579,
+    "base_price": 68.37,
+    "volatility": 0.15,
+    "story": "Quantum-enhanced ecosystem delivering seamless orchestration for talent collectives."
+  },
+  {
+    "ticker": "SOL",
+    "name": "Solar Launch",
+    "sector": "Hospitality & Travel",
+    "region": "South America",
+    "market_cap_millions": 3058,
+    "base_price": 123.71,
+    "volatility": 0.22,
+    "story": "Open-source experience layer delivering resilient performance for cooperative lenders."
+  },
+  {
+    "ticker": "STR",
+    "name": "Strata Agritech",
+    "sector": "Consumer Staples",
+    "region": "Oceania",
+    "market_cap_millions": 5751,
+    "base_price": 41.17,
+    "volatility": 0.31,
+    "story": "Data-rich operations hub delivering collaborative intelligence for metaverse travelers."
+  },
+  {
+    "ticker": "TID",
+    "name": "Tidal Fabrication",
+    "sector": "Financial Services",
+    "region": "Asia-Pacific",
+    "market_cap_millions": 2716,
+    "base_price": 31.83,
+    "volatility": 0.15,
+    "story": "Open-source ecosystem delivering immersive engagement for metaverse travelers."
+  },
+  {
+    "ticker": "TRA",
+    "name": "Strata Homes",
+    "sector": "Supply Chain",
+    "region": "North America",
+    "market_cap_millions": 5116,
+    "base_price": 54.24,
+    "volatility": 0.34,
+    "story": "Cyber-resilient ecosystem delivering seamless orchestration for talent collectives."
+  },
+  {
+    "ticker": "TRI",
+    "name": "Trident Vehicles",
+    "sector": "Digital Identity",
+    "region": "North America",
+    "market_cap_millions": 1466,
+    "base_price": 25.1,
+    "volatility": 0.35,
+    "story": "Immersive experience layer delivering real-time insights for virtual health teams."
+  },
+  {
+    "ticker": "TTI",
+    "name": "Lattice Identity",
+    "sector": "Healthcare",
+    "region": "Global",
+    "market_cap_millions": 1594,
+    "base_price": 19.51,
+    "volatility": 0.21,
+    "story": "Community-owned infrastructure delivering trustworthy automation for next-gen merchants."
+  },
+  {
+    "ticker": "UAN",
+    "name": "Quanta Supply",
+    "sector": "Robotics",
+    "region": "Global",
+    "market_cap_millions": 5102,
+    "base_price": 123.36,
+    "volatility": 0.25,
+    "story": "Autonomous marketplace delivering trustworthy automation for digital citizens."
+  },
+  {
+    "ticker": "UAR",
+    "name": "Quarry Environments",
+    "sector": "Green Construction",
+    "region": "South America",
+    "market_cap_millions": 2725,
+    "base_price": 78.79,
+    "volatility": 0.29,
+    "story": "Bioadaptive operations hub delivering resilient performance for creator guilds."
+  },
+  {
+    "ticker": "ULS",
+    "name": "Pulse Navigation",
+    "sector": "Clean Water",
+    "region": "Nordics",
+    "market_cap_millions": 5098,
+    "base_price": 139.49,
+    "volatility": 0.3,
+    "story": "Machine-learning-guided operations hub delivering real-time insights for creator guilds."
+  },
+  {
+    "ticker": "UMB",
+    "name": "Umber Hospitality",
+    "sector": "Robotics",
+    "region": "Latin America",
+    "market_cap_millions": 1592,
+    "base_price": 44.63,
+    "volatility": 0.29,
+    "story": "Modular ecosystem delivering adaptive planning for urban planners."
+  },
+  {
+    "ticker": "UXI",
+    "name": "Flux Insurance",
+    "sector": "Marine Technology",
+    "region": "Global",
+    "market_cap_millions": 3280,
+    "base_price": 66.28,
+    "volatility": 0.15,
+    "story": "Data-rich infrastructure delivering collaborative intelligence for sustainability stewards."
+  },
+  {
+    "ticker": "VER",
+    "name": "Vertex Insurance",
+    "sector": "Digital Wellness",
+    "region": "Middle East",
+    "market_cap_millions": 2575,
+    "base_price": 153.18,
+    "volatility": 0.19,
+    "story": "Human-centered operations hub delivering trustworthy automation for metaverse travelers."
+  },
+  {
+    "ticker": "WAV",
+    "name": "Wave Structures",
+    "sector": "Energy Storage",
+    "region": "Middle East",
+    "market_cap_millions": 5433,
+    "base_price": 129.95,
+    "volatility": 0.19,
+    "story": "AI-orchestrated experience layer delivering trustworthy automation for creator guilds."
+  },
+  {
+    "ticker": "WIL",
+    "name": "Willow Supply",
+    "sector": "Smart Mobility",
+    "region": "Oceania",
+    "market_cap_millions": 6023,
+    "base_price": 75.98,
+    "volatility": 0.13,
+    "story": "Cloud-native ecosystem delivering seamless orchestration for next-gen merchants."
+  },
+  {
+    "ticker": "YIE",
+    "name": "Yield Wearables",
+    "sector": "Circular Economy",
+    "region": "Nordics",
+    "market_cap_millions": 4884,
+    "base_price": 54.61,
+    "volatility": 0.26,
+    "story": "AI-orchestrated service grid delivering ethical innovation for metaverse travelers."
+  },
+  {
+    "ticker": "YST",
+    "name": "Keystone Networks",
+    "sector": "Marine Technology",
+    "region": "Latin America",
+    "market_cap_millions": 4059,
+    "base_price": 123.3,
+    "volatility": 0.14,
+    "story": "Cloud-native platform delivering collaborative intelligence for sustainability stewards."
+  },
+  {
+    "ticker": "ZEN",
+    "name": "Zenith Commerce",
+    "sector": "Consumer Staples",
+    "region": "South America",
+    "market_cap_millions": 5196,
+    "base_price": 159.29,
+    "volatility": 0.2,
+    "story": "Machine-learning-guided toolkit delivering seamless orchestration for smart-city operators."
+  },
+  {
+    "ticker": "ZEP",
+    "name": "Zephyr Enterprises",
+    "sector": "Energy Storage",
+    "region": "Europe",
+    "market_cap_millions": 2954,
+    "base_price": 85.32,
+    "volatility": 0.24,
+    "story": "Quantum-enhanced experience layer delivering scalable growth for talent collectives."
   }
 ]


### PR DESCRIPTION
## Summary
- expand `dataset/fake_companies.json` to include 100 curated fictional firms spanning sectors, regions, and stories
- update the README dataset section to highlight the broader company coverage
- log the dataset enrichment in the project changelog

## Testing
- python -m json.tool dataset/fake_companies.json

------
https://chatgpt.com/codex/tasks/task_e_68d57889dd7883339eebf590f70d86e3