### PR TITLE
Expand middleware API surface

### DIFF
--- a/Changelog/Changelog.md
+++ b/Changelog/Changelog.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.00.016] Middleware API Surface Expansion
+- **Change Type:** Normal Change
+- **Reason:** Bring the executable middleware in line with the architecture blueprint by exposing credit, market, and session stream touchpoints for downstream teams.
+- **What Changed:** Added credit application and market order endpoints with schema validation, introduced the real-time session WebSocket stream with heartbeat configuration, expanded shared utilities/logging, refreshed the README middleware summary, and updated dependencies to support the new transports.
+
 ## [0.00.015] Middleware Core Service Bootstrap
 - **Change Type:** Normal Change
 - **Reason:** Begin implementing the middleware gateway so the documented transaction flow has an executable foundation for future ledger and stock market integrations.

--- a/README.md
+++ b/README.md
@@ -28,8 +28,13 @@ VirtualBank is a playful online banking simulator for exploring modern money-man
 - [`Changelog/Changelog.md`](Changelog/Changelog.md) – Running log of product and documentation updates.
 
 ## Middleware Core Service
-- **Endpoints:** Health probe at `/health/live`, transfer intake at `/api/v1/transfers`, and status retrieval at `/api/v1/transfers/:id` with schema validation.
-- **Operational guarantees:** Built-in rate limiting, in-memory idempotency cache, structured logging, and configurable environment via `MIDDLEWARE_*` variables.
+- **Endpoints:**
+  - Health probe at `/health/live`.
+  - Transfer intake at `/api/v1/transfers` with status retrieval at `/api/v1/transfers/:id`.
+  - Credit line intake at `/api/v1/credits/applications` for Game Master scoring workflows.
+  - Market order intake at `/api/v1/market/orders` with limit-order validation.
+- **Streaming:** WebSocket stream at `/api/v1/sessions/stream` that emits ready, heartbeat, and demo portfolio updates so the frontend can wire real-time dashboards.
+- **Operational guarantees:** Built-in rate limiting, in-memory idempotency cache, structured logging hooks for transfers/credits/orders, and configurable environment via `MIDDLEWARE_*` variables (including session heartbeat tuning).
 - **Local development:** Hot-reloading through `npm run dev`, TypeScript compilation with `npm run build`, and production-ready Docker image leveraging a distroless runtime.
 
 ## Datasets

--- a/app/middleware/package-lock.json
+++ b/app/middleware/package-lock.json
@@ -13,6 +13,7 @@
         "@fastify/rate-limit": "^10.3.0",
         "@fastify/sensible": "^6.0.3",
         "@fastify/type-provider-typebox": "^5.0.0",
+        "@fastify/websocket": "^11.2.0",
         "@sinclair/typebox": "^0.32.30",
         "fastify": "^4.28.1",
         "fastify-plugin": "^4.5.1",
@@ -20,6 +21,7 @@
       },
       "devDependencies": {
         "@types/node": "^20.12.7",
+        "@types/ws": "^8.18.1",
         "pino-pretty": "^11.0.0",
         "tsx": "^4.7.1",
         "typescript": "^5.4.5"
@@ -615,6 +617,33 @@
         "@sinclair/typebox": ">=0.26 <=0.34"
       }
     },
+    "node_modules/@fastify/websocket": {
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/@fastify/websocket/-/websocket-11.2.0.tgz",
+      "integrity": "sha512-3HrDPbAG1CzUCqnslgJxppvzaAZffieOVbLp1DAy1huCSynUWPifSvfdEDUR8HlJLp3sp1A36uOM2tJogADS8w==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "duplexify": "^4.1.3",
+        "fastify-plugin": "^5.0.0",
+        "ws": "^8.16.0"
+      }
+    },
+    "node_modules/@fastify/websocket/node_modules/fastify-plugin": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/fastify-plugin/-/fastify-plugin-5.0.1.tgz",
+      "integrity": "sha512-HCxs+YnRaWzCl+cWRYFnHmeRFyR5GVnJTAaCJQiYzQSDwK9MgJdyAsuL3nh0EWRCYMgQ5MeziymvmAhUHYHDUQ==",
+      "license": "MIT"
+    },
     "node_modules/@lukeed/ms": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/@lukeed/ms/-/ms-2.0.2.tgz",
@@ -638,6 +667,16 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/abort-controller": {
@@ -814,11 +853,36 @@
         "node": ">=6"
       }
     },
+    "node_modules/duplexify": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-4.1.3.tgz",
+      "integrity": "sha512-M3BmBhwJRZsSx38lZyhE53Csddgzl5R7xGJNk7CVddZD6CcmwMCH8J+7AprIrQKH7TonKxaCjcv27Qmf+sQ+oA==",
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.4.1",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1",
+        "stream-shift": "^1.0.2"
+      }
+    },
+    "node_modules/duplexify/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/end-of-stream": {
       "version": "1.4.5",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
       "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "once": "^1.4.0"
@@ -1314,7 +1378,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
@@ -1613,6 +1676,12 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/stream-shift": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.3.tgz",
+      "integrity": "sha512-76ORR0DO1o1hlKwTbi/DM3EXWGf3ZJYO8cXX5RJwnul2DEg2oyoZyjLNoQM8WsvZiFKCRfC1O0J7iCvie3RZmQ==",
+      "license": "MIT"
+    },
     "node_modules/string_decoder": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
@@ -1716,6 +1785,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
+    },
     "node_modules/vary": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
@@ -1729,8 +1804,28 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-      "dev": true,
       "license": "ISC"
+    },
+    "node_modules/ws": {
+      "version": "8.18.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
+      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
     }
   }
 }

--- a/app/middleware/package.json
+++ b/app/middleware/package.json
@@ -15,6 +15,7 @@
     "@fastify/rate-limit": "^10.3.0",
     "@fastify/sensible": "^6.0.3",
     "@fastify/type-provider-typebox": "^5.0.0",
+    "@fastify/websocket": "^11.2.0",
     "@sinclair/typebox": "^0.32.30",
     "fastify": "^4.28.1",
     "fastify-plugin": "^4.5.1",
@@ -22,6 +23,7 @@
   },
   "devDependencies": {
     "@types/node": "^20.12.7",
+    "@types/ws": "^8.18.1",
     "pino-pretty": "^11.0.0",
     "tsx": "^4.7.1",
     "typescript": "^5.4.5"

--- a/app/middleware/src/config/env.ts
+++ b/app/middleware/src/config/env.ts
@@ -11,7 +11,8 @@ const EnvSchema = Type.Object({
   RATE_LIMIT_MAX: Type.Optional(Type.String({ default: '100' })),
   RATE_LIMIT_TIME_WINDOW: Type.Optional(Type.String({ default: '1 minute' })),
   IDEMPOTENCY_TTL_SECONDS: Type.Optional(Type.String({ default: '600' })),
-  PUBLIC_BASE_URL: Type.Optional(Type.String())
+  PUBLIC_BASE_URL: Type.Optional(Type.String()),
+  SESSION_STREAM_HEARTBEAT_SECONDS: Type.Optional(Type.String({ default: '30' }))
 });
 
 export type EnvConfig = Static<typeof EnvSchema>;
@@ -32,6 +33,7 @@ export function parseEnv(env: NodeJS.ProcessEnv): EnvConfig {
     RATE_LIMIT_MAX: result.RATE_LIMIT_MAX ?? '100',
     RATE_LIMIT_TIME_WINDOW: result.RATE_LIMIT_TIME_WINDOW ?? '1 minute',
     IDEMPOTENCY_TTL_SECONDS: result.IDEMPOTENCY_TTL_SECONDS ?? '600',
-    PUBLIC_BASE_URL: result.PUBLIC_BASE_URL
+    PUBLIC_BASE_URL: result.PUBLIC_BASE_URL,
+    SESSION_STREAM_HEARTBEAT_SECONDS: result.SESSION_STREAM_HEARTBEAT_SECONDS ?? '30'
   };
 }

--- a/app/middleware/src/config/index.ts
+++ b/app/middleware/src/config/index.ts
@@ -13,5 +13,9 @@ export const config = {
   idempotency: {
     ttlSeconds: Number(env.IDEMPOTENCY_TTL_SECONDS ?? '600')
   },
-  publicBaseUrl: env.PUBLIC_BASE_URL ?? `http://${env.MIDDLEWARE_HOST ?? '0.0.0.0'}:${env.MIDDLEWARE_PORT ?? '8080'}`
+  publicBaseUrl:
+    env.PUBLIC_BASE_URL ?? `http://${env.MIDDLEWARE_HOST ?? '0.0.0.0'}:${env.MIDDLEWARE_PORT ?? '8080'}`,
+  sessionStream: {
+    heartbeatSeconds: Number(env.SESSION_STREAM_HEARTBEAT_SECONDS ?? '30')
+  }
 } as const;

--- a/app/middleware/src/index.ts
+++ b/app/middleware/src/index.ts
@@ -4,11 +4,15 @@ import helmet from '@fastify/helmet';
 import cors from '@fastify/cors';
 import rateLimit from '@fastify/rate-limit';
 import { TypeBoxTypeProvider } from '@fastify/type-provider-typebox';
+import websocket from '@fastify/websocket';
 import { config } from './config/index.js';
 import { idempotencyPlugin } from './plugins/idempotency.js';
 import { decoratorPlugin } from './plugins/decorators.js';
 import { healthRoutes } from './routes/health.js';
 import { transferRoutes } from './routes/transfers.js';
+import { creditRoutes } from './routes/credits.js';
+import { marketRoutes } from './routes/market.js';
+import { sessionRoutes } from './routes/sessions.js';
 
 async function buildServer() {
   const app = Fastify({
@@ -25,11 +29,15 @@ async function buildServer() {
     max: config.rateLimit.max,
     timeWindow: config.rateLimit.timeWindow
   });
+  await app.register(websocket);
   await app.register(decoratorPlugin);
   await app.register(idempotencyPlugin, { ttlSeconds: config.idempotency.ttlSeconds });
 
   await app.register(healthRoutes);
   await app.register(transferRoutes);
+  await app.register(creditRoutes);
+  await app.register(marketRoutes);
+  await app.register(sessionRoutes);
 
   return app;
 }

--- a/app/middleware/src/plugins/decorators.ts
+++ b/app/middleware/src/plugins/decorators.ts
@@ -13,10 +13,48 @@ type TransferIntent = {
   correlationId: string;
 };
 
+type CreditApplicationIntent = {
+  applicationId: string;
+  playerId: string;
+  accountId: string;
+  requestedLimit: number;
+  currency: string;
+  justification: string;
+  collateralType?: string;
+  attachments?: string[];
+  correlationId: string;
+};
+
+type MarketOrderIntent = {
+  orderId: string;
+  accountId: string;
+  symbol: string;
+  side: 'buy' | 'sell';
+  orderType: 'market' | 'limit';
+  quantity: number;
+  limitPrice?: number;
+  timeInForce?: string;
+  correlationId: string;
+};
+
 function generateTransferId(source: string, destination: string) {
   return crypto
     .createHash('sha256')
     .update(`${source}:${destination}:${crypto.randomUUID()}`)
+    .digest('hex');
+}
+
+function generateCreditApplicationId(playerId: string, accountId: string) {
+  return crypto
+    .createHash('sha256')
+    .update(`credit:${playerId}:${accountId}:${crypto.randomUUID()}`)
+    .digest('hex');
+}
+
+function generateMarketOrderId(accountId: string, symbol: string) {
+  return crypto
+    .createHash('sha256')
+    .update(`order:${accountId}:${symbol}:${crypto.randomUUID()}`)
     .digest('hex');
 }
 
@@ -30,11 +68,35 @@ async function logTransferIntent(this: FastifyInstance, intent: TransferIntent) 
   );
 }
 
+async function logCreditApplication(this: FastifyInstance, application: CreditApplicationIntent) {
+  this.log.info(
+    {
+      event: 'credit_application_received',
+      application
+    },
+    'Credit application received'
+  );
+}
+
+async function logMarketOrder(this: FastifyInstance, order: MarketOrderIntent) {
+  this.log.info(
+    {
+      event: 'market_order_received',
+      order
+    },
+    'Market order received'
+  );
+}
+
 export const decoratorPlugin = fp(async (app: FastifyInstance) => {
   app.decorate('config', config);
 
   app.decorate('utils', {
     generateTransferId,
-    logTransferIntent: logTransferIntent.bind(app)
+    generateCreditApplicationId,
+    generateMarketOrderId,
+    logTransferIntent: logTransferIntent.bind(app),
+    logCreditApplication: logCreditApplication.bind(app),
+    logMarketOrder: logMarketOrder.bind(app)
   });
 });

--- a/app/middleware/src/routes/credits.ts
+++ b/app/middleware/src/routes/credits.ts
@@ -1,0 +1,60 @@
+import { Static, Type } from '@sinclair/typebox';
+import type { FastifyInstance } from 'fastify';
+
+const CreditApplicationRequest = Type.Object({
+  playerId: Type.String({ minLength: 1 }),
+  accountId: Type.String({ minLength: 1 }),
+  requestedLimit: Type.Number({ exclusiveMinimum: 0 }),
+  currency: Type.String({ minLength: 3, maxLength: 3 }),
+  justification: Type.String({ minLength: 1, maxLength: 1024 }),
+  collateralType: Type.Optional(Type.String({ minLength: 1, maxLength: 120 })),
+  attachments: Type.Optional(Type.Array(Type.String({ format: 'uri' }), { maxItems: 5 }))
+});
+
+type CreditApplicationRequestType = Static<typeof CreditApplicationRequest>;
+
+const CreditApplicationResponse = Type.Object({
+  applicationId: Type.String(),
+  status: Type.Literal('received'),
+  reviewUrl: Type.String({ format: 'uri' }),
+  estimatedDecisionSeconds: Type.Number({ minimum: 0 })
+});
+
+export async function creditRoutes(app: FastifyInstance) {
+  app.post<{ Body: CreditApplicationRequestType }>(
+    '/api/v1/credits/applications',
+    {
+      schema: {
+        body: CreditApplicationRequest,
+        response: {
+          202: CreditApplicationResponse
+        }
+      }
+    },
+    async (request, reply) => {
+      const { body } = request;
+
+      const applicationId = app.utils.generateCreditApplicationId(body.playerId, body.accountId);
+      const reviewUrl = `${app.config.publicBaseUrl}/api/v1/credits/applications/${applicationId}`;
+
+      await app.utils.logCreditApplication({
+        applicationId,
+        playerId: body.playerId,
+        accountId: body.accountId,
+        requestedLimit: body.requestedLimit,
+        currency: body.currency,
+        justification: body.justification,
+        collateralType: body.collateralType,
+        attachments: body.attachments,
+        correlationId: request.id
+      });
+
+      return reply.code(202).send({
+        applicationId,
+        status: 'received',
+        reviewUrl,
+        estimatedDecisionSeconds: 3600
+      });
+    }
+  );
+}

--- a/app/middleware/src/routes/market.ts
+++ b/app/middleware/src/routes/market.ts
@@ -1,0 +1,62 @@
+import { Static, Type } from '@sinclair/typebox';
+import type { FastifyInstance } from 'fastify';
+
+const MarketOrderRequest = Type.Object({
+  accountId: Type.String({ minLength: 1 }),
+  symbol: Type.String({ minLength: 1, maxLength: 12 }),
+  side: Type.Union([Type.Literal('buy'), Type.Literal('sell')]),
+  orderType: Type.Union([Type.Literal('market'), Type.Literal('limit')]),
+  quantity: Type.Number({ exclusiveMinimum: 0 }),
+  limitPrice: Type.Optional(Type.Number({ exclusiveMinimum: 0 })),
+  timeInForce: Type.Optional(Type.String({ minLength: 2, maxLength: 3 }))
+});
+
+type MarketOrderRequestType = Static<typeof MarketOrderRequest>;
+
+const MarketOrderResponse = Type.Object({
+  orderId: Type.String(),
+  status: Type.Literal('accepted'),
+  statusUrl: Type.String({ format: 'uri' })
+});
+
+export async function marketRoutes(app: FastifyInstance) {
+  app.post<{ Body: MarketOrderRequestType }>(
+    '/api/v1/market/orders',
+    {
+      schema: {
+        body: MarketOrderRequest,
+        response: {
+          202: MarketOrderResponse
+        }
+      }
+    },
+    async (request, reply) => {
+      const { body } = request;
+
+      if (body.orderType === 'limit' && typeof body.limitPrice !== 'number') {
+        throw app.httpErrors.badRequest('limitPrice is required for limit orders.');
+      }
+
+      const orderId = app.utils.generateMarketOrderId(body.accountId, body.symbol);
+      const statusUrl = `${app.config.publicBaseUrl}/api/v1/market/orders/${orderId}`;
+
+      await app.utils.logMarketOrder({
+        orderId,
+        accountId: body.accountId,
+        symbol: body.symbol,
+        side: body.side,
+        orderType: body.orderType,
+        quantity: body.quantity,
+        limitPrice: body.limitPrice,
+        timeInForce: body.timeInForce,
+        correlationId: request.id
+      });
+
+      return reply.code(202).send({
+        orderId,
+        status: 'accepted',
+        statusUrl
+      });
+    }
+  );
+}

--- a/app/middleware/src/routes/sessions.ts
+++ b/app/middleware/src/routes/sessions.ts
@@ -1,0 +1,56 @@
+import type { FastifyInstance } from 'fastify';
+import type { FastifyRequest } from 'fastify';
+import type { WebsocketHandler } from '@fastify/websocket';
+import type WebSocket from 'ws';
+
+function send(socket: WebSocket, payload: unknown) {
+  if (socket.readyState === socket.OPEN) {
+    socket.send(JSON.stringify(payload));
+  }
+}
+
+export async function sessionRoutes(app: FastifyInstance) {
+  const handler: WebsocketHandler = (connection: WebSocket, request: FastifyRequest) => {
+    app.log.info({ event: 'session_stream_connected', correlationId: request.id }, 'Session stream subscribed');
+
+    send(connection, {
+      type: 'session.stream.ready',
+      correlationId: request.id,
+      acknowledgedAt: new Date().toISOString(),
+      nextHeartbeatSeconds: app.config.sessionStream.heartbeatSeconds
+    });
+
+    const heartbeat = setInterval(() => {
+      send(connection, {
+        type: 'session.stream.heartbeat',
+        emittedAt: new Date().toISOString()
+      });
+    }, app.config.sessionStream.heartbeatSeconds * 1000);
+
+    const demoUpdateTimer = setTimeout(() => {
+      send(connection, {
+        type: 'session.stream.update',
+        emittedAt: new Date().toISOString(),
+        portfolio: {
+          cashBalance: 1250.32,
+          currency: 'VBC',
+          holdings: [
+            { symbol: 'SOLARX', quantity: 12, marketValue: 480.5 },
+            { symbol: 'MECH-PRIME', quantity: 3, marketValue: 356.0 }
+          ]
+        },
+        recentActivity: [
+          { id: app.utils.generateTransferId('demo', 'player'), status: 'settled', occurredAt: new Date().toISOString() }
+        ]
+      });
+    }, 1500);
+
+    connection.on('close', () => {
+      clearInterval(heartbeat);
+      clearTimeout(demoUpdateTimer);
+      app.log.info({ event: 'session_stream_disconnected', correlationId: request.id }, 'Session stream closed');
+    });
+  };
+
+  app.get('/api/v1/sessions/stream', { websocket: true }, handler);
+}

--- a/app/middleware/src/types/fastify.d.ts
+++ b/app/middleware/src/types/fastify.d.ts
@@ -8,6 +8,8 @@ declare module 'fastify' {
     config: ConfigShape;
     utils: {
       generateTransferId: (sourceAccountId: string, destinationAccountId: string) => string;
+      generateCreditApplicationId: (playerId: string, accountId: string) => string;
+      generateMarketOrderId: (accountId: string, symbol: string) => string;
       logTransferIntent: (intent: {
         transferId: string;
         sourceAccountId: string;
@@ -15,6 +17,28 @@ declare module 'fastify' {
         amount: number;
         currency: string;
         note?: string;
+        correlationId: string;
+      }) => Promise<void> | void;
+      logCreditApplication: (application: {
+        applicationId: string;
+        playerId: string;
+        accountId: string;
+        requestedLimit: number;
+        currency: string;
+        justification: string;
+        collateralType?: string;
+        attachments?: string[];
+        correlationId: string;
+      }) => Promise<void> | void;
+      logMarketOrder: (order: {
+        orderId: string;
+        accountId: string;
+        symbol: string;
+        side: 'buy' | 'sell';
+        orderType: 'market' | 'limit';
+        quantity: number;
+        limitPrice?: number;
+        timeInForce?: string;
         correlationId: string;
       }) => Promise<void> | void;
     };


### PR DESCRIPTION
## Summary
- add credit application and market order endpoints with schema validation and logging hooks
- expose the session stream WebSocket with configurable heartbeats and demo updates
- wire websocket support and utilities into the middleware along with docs and dependency updates

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d57ed4acf483338d4ad15e2df130cd