### PR TITLE
Add automated maintenance script

### DIFF
--- a/Changelog/Changelog.md
+++ b/Changelog/Changelog.md
@@ -1,4 +1,8 @@
 # Changelog
+## [0.00.020] Automated Maintenance Toolkit
+- **Change Type:** Normal Change
+- **Reason:** Provide administrators with a reliable way to install, update, and remove VirtualBank environments with minimal manual effort.
+- **What Changed:** Added the `scripts/maintenance.sh` automation script that manages cloning, dependency checks, Docker Compose stacks, updates, and full removal; refreshed the README with usage guidance for the new tooling; and documented the enhancement here.
 ## [0.00.019] Frontend Experience Shell
 - **Change Type:** Normal Change
 - **Reason:** Deliver an executable foundation for the heart of the VirtualBank experience so teams can iterate on the documented UX flows.

--- a/README.md
+++ b/README.md
@@ -10,6 +10,18 @@ VirtualBank is a playful online banking simulator for exploring modern money-man
 5. Launch the data store foundation locally with `docker compose -f apps/datastore/datastore-compose.yml up --build` when you want PostgreSQL, Redis, Kafka, ClickHouse, and MinIO services that mirror the reference architecture.
 6. Explore the design blueprints in [`docs/designing/design.md`](docs/designing/design.md) to understand the planned player journeys and backend integrations.
 
+## Automated Maintenance
+The `scripts/maintenance.sh` helper orchestrates installation and lifecycle tasks for production-like environments. Execute the script as `root` (or with `sudo`) and pass one of the following commands:
+
+| Command | Description |
+| --- | --- |
+| `install` | Clones the upstream repository into `/opt/VirtualBank`, verifies Docker tooling, and starts the middleware and datastore stacks. |
+| `update` | Pulls the latest commits, rebuilds containers, and reapplies the Docker Compose stacks. |
+| `uninstall` | Stops active Compose services, removes related volumes, and deletes `/opt/VirtualBank`. |
+| `check-updates` | Contacts GitHub to determine whether newer commits are available without applying changes. |
+
+Example usage: `sudo ./scripts/maintenance.sh install`.
+
 ## Highlights
 - **Best-in-class UX** with responsive, accessible interfaces and gamified feedback loops.
 - **Secure middleware gateway** powered by Fastify, JSON Schema validation, and idempotent transaction intake.

--- a/scripts/maintenance.sh
+++ b/scripts/maintenance.sh
@@ -1,0 +1,282 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_URL="https://github.com/AsaTyr2018/VirtualBank"
+INSTALL_DIR="/opt/VirtualBank"
+COMPOSE_FILE="middleware-compose.yml"
+DATASTORE_COMPOSE="apps/datastore/datastore-compose.yml"
+
+log() { printf "[%(%Y-%m-%dT%H:%M:%S%z)T] %s\n" -1 "$*"; }
+error() { log "ERROR: $*" >&2; }
+
+require_root() {
+  if [[ "${EUID:-$(id -u)}" -ne 0 ]]; then
+    error "This script must be run as root."
+    exit 1
+  fi
+}
+
+has_command() { command -v "$1" >/dev/null 2>&1; }
+
+PACKAGE_MANAGER=""
+
+detect_package_manager() {
+  if [[ -n "${PACKAGE_MANAGER}" ]]; then
+    return
+  fi
+  local managers=(apt-get dnf yum zypper pacman)
+  for manager in "${managers[@]}"; do
+    if has_command "$manager"; then
+      PACKAGE_MANAGER="$manager"
+      return
+    fi
+  done
+  PACKAGE_MANAGER=""
+}
+
+install_packages() {
+  local packages=()
+  for pkg in "$@"; do
+    packages+=("$pkg")
+  done
+  detect_package_manager
+  if [[ -z "${PACKAGE_MANAGER}" ]]; then
+    error "No supported package manager found to install packages: ${packages[*]}"
+    exit 1
+  fi
+  case "$PACKAGE_MANAGER" in
+    apt-get)
+      log "Installing missing packages: ${packages[*]}"
+      apt-get update -y
+      DEBIAN_FRONTEND=noninteractive apt-get install -y "${packages[@]}"
+      ;;
+    dnf|yum)
+      log "Installing missing packages: ${packages[*]}"
+      "$PACKAGE_MANAGER" install -y "${packages[@]}"
+      ;;
+    zypper)
+      log "Installing missing packages: ${packages[*]}"
+      zypper install -y "${packages[@]}"
+      ;;
+    pacman)
+      log "Installing missing packages: ${packages[*]}"
+      pacman -Sy --noconfirm "${packages[@]}"
+      ;;
+    *)
+      error "Unsupported package manager: $PACKAGE_MANAGER"
+      exit 1
+      ;;
+  esac
+}
+
+ensure_dependency() {
+  local cmd="$1"
+  local pkg="$2"
+  if has_command "$cmd"; then
+    return
+  fi
+  log "Dependency '$cmd' missing. Attempting to install package '$pkg'."
+  install_packages "$pkg"
+  if ! has_command "$cmd"; then
+    error "Unable to install required dependency '$cmd'."
+    exit 1
+  fi
+}
+
+ensure_docker_compose() {
+  if has_command "docker" && docker compose version >/dev/null 2>&1; then
+    echo "docker compose"
+    return
+  fi
+  if has_command "docker-compose"; then
+    echo "docker-compose"
+    return
+  fi
+  log "Docker Compose not found. Attempting to install docker-compose plugin."
+  install_packages "docker-compose-plugin"
+  if has_command "docker" && docker compose version >/dev/null 2>&1; then
+    echo "docker compose"
+    return
+  fi
+  install_packages "docker-compose"
+  if has_command "docker-compose"; then
+    echo "docker-compose"
+    return
+  fi
+  error "Unable to install Docker Compose."
+  exit 1
+}
+
+ensure_docker_running() {
+  if systemctl is-active --quiet docker 2>/dev/null; then
+    return
+  fi
+  log "Docker daemon not running. Attempting to start."
+  if systemctl start docker 2>/dev/null; then
+    return
+  fi
+  if service docker start 2>/dev/null; then
+    return
+  fi
+  error "Docker daemon is not running and could not be started automatically."
+  exit 1
+}
+
+clone_or_update_repo() {
+  if [[ -d "${INSTALL_DIR}/.git" ]]; then
+    log "Existing repository detected. Fetching updates."
+    git -C "$INSTALL_DIR" fetch --all --prune
+    git -C "$INSTALL_DIR" reset --hard origin/main
+  else
+    log "Cloning repository into ${INSTALL_DIR}."
+    rm -rf "$INSTALL_DIR"
+    git clone "$REPO_URL" "$INSTALL_DIR"
+  fi
+}
+
+pull_updates() {
+  if [[ ! -d "${INSTALL_DIR}/.git" ]]; then
+    error "Installation directory does not contain a Git repository."
+    exit 1
+  fi
+  log "Fetching latest updates from origin."
+  git -C "$INSTALL_DIR" fetch --all --prune
+}
+
+rebuild_stack() {
+  local compose_cmd
+  compose_cmd="$(ensure_docker_compose)"
+  ensure_docker_running
+  if [[ -f "${INSTALL_DIR}/${COMPOSE_FILE}" ]]; then
+    log "Updating middleware stack using ${compose_cmd}."
+    (cd "$INSTALL_DIR" && $compose_cmd -f "$COMPOSE_FILE" pull)
+    (cd "$INSTALL_DIR" && $compose_cmd -f "$COMPOSE_FILE" up -d --build)
+  else
+    log "Middleware compose file not found; skipping middleware deployment."
+  fi
+  if [[ -f "${INSTALL_DIR}/${DATASTORE_COMPOSE}" ]]; then
+    log "Ensuring datastore stack is prepared using ${compose_cmd}."
+    (cd "$INSTALL_DIR" && $compose_cmd -f "$DATASTORE_COMPOSE" pull)
+    (cd "$INSTALL_DIR" && $compose_cmd -f "$DATASTORE_COMPOSE" up -d --build)
+  else
+    log "Datastore compose file not found; skipping datastore deployment."
+  fi
+}
+
+install_virtualbank() {
+  require_root
+  ensure_dependency git git
+  ensure_dependency docker docker.io
+  local compose_cmd
+  compose_cmd="$(ensure_docker_compose)"
+  clone_or_update_repo
+  ensure_docker_running
+  log "Verifying docker command availability."
+  docker version >/dev/null
+  log "Bringing infrastructure online."
+  rebuild_stack
+  log "Installation completed successfully."
+}
+
+update_virtualbank() {
+  require_root
+  ensure_dependency git git
+  ensure_dependency docker docker.io
+  pull_updates
+  log "Comparing commits."
+  local status
+  status=$(git -C "$INSTALL_DIR" rev-list HEAD..origin/main --count)
+  if [[ "$status" -eq 0 ]]; then
+    log "No updates available."
+    return
+  fi
+  log "Applying updates (origin/main)."
+  git -C "$INSTALL_DIR" reset --hard origin/main
+  rebuild_stack
+  log "Update completed successfully."
+}
+
+check_updates() {
+  ensure_dependency git git
+  if [[ ! -d "${INSTALL_DIR}/.git" ]]; then
+    log "VirtualBank is not installed at ${INSTALL_DIR}."
+    exit 0
+  fi
+  pull_updates
+  local ahead behind
+  ahead=$(git -C "$INSTALL_DIR" rev-list origin/main..HEAD --count)
+  behind=$(git -C "$INSTALL_DIR" rev-list HEAD..origin/main --count)
+  if [[ "$behind" -gt 0 ]]; then
+    log "Updates are available. Local installation is ${behind} commit(s) behind origin/main."
+  elif [[ "$ahead" -gt 0 ]]; then
+    log "Local installation has ${ahead} commit(s) not on origin/main."
+  else
+    log "VirtualBank is up-to-date."
+  fi
+}
+
+uninstall_virtualbank() {
+  require_root
+  if [[ -d "${INSTALL_DIR}" ]]; then
+    local compose_cmd
+    if has_command docker; then
+      compose_cmd=$(ensure_docker_compose)
+      if [[ -f "${INSTALL_DIR}/${COMPOSE_FILE}" ]]; then
+        log "Stopping middleware stack."
+        (cd "$INSTALL_DIR" && $compose_cmd -f "$COMPOSE_FILE" down --remove-orphans)
+      fi
+      if [[ -f "${INSTALL_DIR}/${DATASTORE_COMPOSE}" ]]; then
+        log "Stopping datastore stack."
+        (cd "$INSTALL_DIR" && $compose_cmd -f "$DATASTORE_COMPOSE" down --remove-orphans -v)
+      fi
+    fi
+    log "Removing installation directory ${INSTALL_DIR}."
+    rm -rf "$INSTALL_DIR"
+  else
+    log "Installation directory ${INSTALL_DIR} does not exist. Nothing to remove."
+  fi
+  log "Uninstallation completed."
+}
+
+usage() {
+  cat <<USAGE
+VirtualBank maintenance script
+
+Usage: $0 <command>
+
+Commands:
+  install        Install VirtualBank under ${INSTALL_DIR}
+  update         Update the existing VirtualBank deployment
+  uninstall      Remove VirtualBank and associated Docker stacks
+  check-updates  Check whether updates are available from GitHub
+  help           Display this help message
+USAGE
+}
+
+main() {
+  local command=${1:-help}
+  case "$command" in
+    install)
+      install_virtualbank
+      ;;
+    update)
+      update_virtualbank
+      ;;
+    uninstall)
+      uninstall_virtualbank
+      ;;
+    check-updates)
+      check_updates
+      ;;
+    help|--help|-h)
+      usage
+      ;;
+    *)
+      error "Unknown command: $command"
+      usage
+      exit 1
+      ;;
+  esac
+}
+
+main "$@"


### PR DESCRIPTION
## Summary
- add a maintenance utility script that automates installation, updates, uninstallation, and update checks for VirtualBank under /opt/VirtualBank
- ensure the script validates dependencies, manages Docker Compose stacks, and preserves the Git repository for future pulls
- document the automation workflow in the README and record the change in the changelog

## Testing
- ./scripts/maintenance.sh help

------
https://chatgpt.com/codex/tasks/task_e_68d59dc5a3e88333af4225cadb0b8490