### PR TITLE
Resolve datastore port conflicts

### DIFF
--- a/Changelog/Changelog.md
+++ b/Changelog/Changelog.md
@@ -1,4 +1,8 @@
 # Changelog
+## [0.00.022] Datastore Port Collision Fix
+- **Change Type:** Emergency Change
+- **Reason:** Docker reported binding failures because PostgreSQL and ClickHouse ports overlapped with existing host services and other stack assignments, preventing the datastore stack from starting.
+- **What Changed:** Remapped the PostgreSQL primary/replica to host ports `15432/15433`, shifted the ClickHouse native listener to host port `19000`, and refreshed the README with updated port guidance and a service table so developers can connect without clashes.
 ## [0.00.021] Middleware Datastore Wiring
 - **Change Type:** Normal Change
 - **Reason:** Ensure the middleware can talk to PostgreSQL out of the box and ship environments with the fake market dataset preloaded.

--- a/apps/datastore/datastore-compose.yml
+++ b/apps/datastore/datastore-compose.yml
@@ -5,7 +5,7 @@ services:
     image: bitnami/postgresql:16.3.0
     container_name: vb-postgres-primary
     ports:
-      - "5432:5432"
+      - "15432:5432"
     environment:
       - POSTGRESQL_USERNAME=vb_app
       - POSTGRESQL_PASSWORD=vb_app_password
@@ -33,7 +33,7 @@ services:
       postgres-primary:
         condition: service_healthy
     ports:
-      - "5433:5432"
+      - "15433:5432"
     environment:
       - POSTGRESQL_USERNAME=vb_app
       - POSTGRESQL_PASSWORD=vb_app_password
@@ -108,7 +108,7 @@ services:
     container_name: vb-clickhouse
     ports:
       - "8123:8123"
-      - "9000:9000"
+      - "19000:9000"
     volumes:
       - clickhouse-data:/var/lib/clickhouse
       - clickhouse-logs:/var/log/clickhouse-server


### PR DESCRIPTION
## Summary
- remap the datastore compose ports so PostgreSQL and ClickHouse no longer collide with host services
- refresh the README with updated port guidance and a datastore service port table
- document the emergency change in the changelog

## Testing
- not run (docker-compose configuration change only)


------
https://chatgpt.com/codex/tasks/task_e_68d5aa215bac8333a86a2dde945e4082