### PR TITLE
Align compose ports to avoid frontend collisions

### DIFF
--- a/Changelog/Changelog.md
+++ b/Changelog/Changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [0.00.026] Compose Port Isolation
+- **Change Type:** Standard Change
+- **Reason:** Running multiple stacks concurrently caused Docker to compete for port `5173`, blocking the middleware stack when the standalone frontend was already bound to the host.
+- **What Changed:** Gave the middleware stack a dedicated `MIDDLEWARE_FRONTEND_WEB_PORT` host binding (default `5174`), kept the standalone frontend on a configurable `FRONTEND_WEB_PORT`, exposed `FRONTEND_DEV_PORT` overrides in the Vite config, and refreshed the README with the new port guidance.
 ## [0.00.025] Frontend Port Override
 - **Change Type:** Standard Change
 - **Reason:** Local development environments frequently already use port `5173`, preventing the frontend Docker stack from starting.

--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@ VirtualBank is a playful online banking simulator for exploring modern money-man
 ## Quickstart
 1. Clone the repository and install dependencies for the middleware prototype: `cd app/middleware && npm install`.
 2. Start the TypeScript Fastify server locally with `npm run dev` (listens on `http://localhost:8080`).
-3. Bootstrap the new frontend shell with `cd app/frontend && npm install` followed by `npm run dev` (served from `http://localhost:5173`).
+3. Bootstrap the new frontend shell with `cd app/frontend && npm install` followed by `FRONTEND_DEV_PORT=5317 npm run dev` when you need a custom dev port (defaults to `http://localhost:5173`).
 4. Prefer Docker Compose for isolated stacks:
-   - Middleware only: `docker compose -f middleware-compose.yml up --build` (publishes `http://localhost:8080`).
+   - Middleware only: `docker compose -f middleware-compose.yml up --build` (publishes the API at `http://localhost:8080` and the bundled preview UI at `http://localhost:5174`; remap the UI port with `MIDDLEWARE_FRONTEND_WEB_PORT=5318 docker compose -f middleware-compose.yml up --build`).
    - Frontend only: `docker compose -f frontend-compose.yml up --build` (serves `http://localhost:5173` by default; override the host port with `FRONTEND_WEB_PORT=5317 docker compose -f frontend-compose.yml up --build` when another service already occupies `5173`).
 5. Launch the data store foundation locally with `docker compose -f apps/datastore/datastore-compose.yml up --build` when you want PostgreSQL, Redis, Kafka, ClickHouse, and MinIO services that mirror the reference architecture. Host bindings avoid common developer ports (`15432/15433` for PostgreSQL and `19000` for the ClickHouse native wire) so local installations stay untouched. The maintenance script automatically seeds the `market_companies` table from [`docs/dataset/fake_companies.json`](docs/dataset/fake_companies.json) once PostgreSQL reports healthy.
 6. Explore the design blueprints in [`docs/designing/design.md`](docs/designing/design.md) to understand the planned player journeys and backend integrations.
@@ -37,7 +37,7 @@ Both `install` and `update` wait for the PostgreSQL primary to become ready and 
 - **Technology stack:** React + TypeScript + Vite with React Query and Zustand managing optimistic data flows.
 - **Feature highlights:** Guided onboarding journey, real-time dashboard metrics, celebratory transfer wizard, market desk heatmaps, and Game Master governance console.
 - **Design language:** Inspired by the [HTML concept previews](docs/design/Frontend/) with soft gradients, accessible typography, and micro-interaction friendly components.
-- **Docker support:** Use the dedicated Compose stack (`docker compose -f frontend-compose.yml up --build`) to build the image and run `vite preview`, making the UI available at `http://localhost:5173` without coupling it to other services.
+- **Docker support:** Use the dedicated Compose stack (`docker compose -f frontend-compose.yml up --build`) to build the image and run `vite preview`, making the UI available at `http://localhost:5173` (override with `FRONTEND_WEB_PORT`) without coupling it to other services.
 
 ## Project Structure
 - `app/` – Runtime services under active development.
@@ -55,7 +55,7 @@ Both `install` and `update` wait for the PostgreSQL primary to become ready and 
 - [`Changelog/Changelog.md`](Changelog/Changelog.md) – Running log of product and documentation updates.
 
 ### Troubleshooting
-- **Frontend port already in use:** Vite preview binds the host port defined by `FRONTEND_WEB_PORT` (default `5173`). Stop the conflicting service or relaunch the stack with a new host port, for example `FRONTEND_WEB_PORT=5317 docker compose -f frontend-compose.yml up --build`.
+- **Frontend port already in use:** Use `FRONTEND_DEV_PORT` (for `npm run dev`), `FRONTEND_PREVIEW_PORT` (for `npm run preview`), `FRONTEND_WEB_PORT` (for the standalone Compose stack), or `MIDDLEWARE_FRONTEND_WEB_PORT` (for the middleware stack) to remap the host port when `5173/5174` are occupied.
 
 ## Data Store Stack
 The `apps/datastore/datastore-compose.yml` stack mirrors the architecture defined in the data store blueprint. It provisions:

--- a/app/frontend/vite.config.ts
+++ b/app/frontend/vite.config.ts
@@ -1,10 +1,17 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 
+const devPort = Number(process.env.FRONTEND_DEV_PORT ?? process.env.VITE_DEV_PORT ?? 5173);
+const previewPort = Number(process.env.FRONTEND_PREVIEW_PORT ?? process.env.VITE_PREVIEW_PORT ?? devPort);
+
 export default defineConfig({
   plugins: [react()],
   server: {
-    port: 5173,
+    port: devPort,
+    host: true
+  },
+  preview: {
+    port: previewPort,
     host: true
   }
 });

--- a/middleware-compose.yml
+++ b/middleware-compose.yml
@@ -19,9 +19,10 @@ services:
     build:
       context: ./app/frontend
     ports:
-      - "5173:5173"
+      - "${MIDDLEWARE_FRONTEND_WEB_PORT:-5174}:5173"
     environment:
       NODE_ENV: production
+    command: npm run preview -- --host 0.0.0.0 --port 5173
     depends_on:
       - middleware-core
     restart: unless-stopped


### PR DESCRIPTION
## Summary
- assign the middleware stack frontend preview to a dedicated `MIDDLEWARE_FRONTEND_WEB_PORT` host binding so it can run beside the standalone frontend stack without clashing on port 5173
- expose environment-based dev/preview port overrides for the Vite frontend and refresh the README with new port guidance
- log the update in the changelog for visibility

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d5b3a810c083339486d17eff7572d9