### PR TITLE
Fix middleware helmet plugin version mismatch

### DIFF
--- a/Changelog/Changelog.md
+++ b/Changelog/Changelog.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.00.027] Middleware Helmet Compatibility
+- **Change Type:** Emergency Change
+- **Reason:** The middleware container crashed during startup because `@fastify/helmet` v13 requires Fastify v5, while the stack still ships Fastify v4, causing Docker deployments to fail immediately.
+- **What Changed:** Downgraded `@fastify/helmet` to the v12 line that remains compatible with Fastify v4 and refreshed the lockfile to keep the middleware container bootable.
+
 ## [0.00.026] Compose Port Isolation
 - **Change Type:** Standard Change
 - **Reason:** Running multiple stacks concurrently caused Docker to compete for port `5173`, blocking the middleware stack when the standalone frontend was already bound to the host.

--- a/app/middleware/package-lock.json
+++ b/app/middleware/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@fastify/cors": "^9.0.1",
-        "@fastify/helmet": "^13.0.1",
+        "@fastify/helmet": "^12.0.0",
         "@fastify/rate-limit": "^10.3.0",
         "@fastify/sensible": "^4.1.0",
         "@fastify/type-provider-typebox": "^5.0.0",
@@ -508,23 +508,13 @@
       }
     },
     "node_modules/@fastify/helmet": {
-      "version": "13.0.1",
-      "resolved": "https://registry.npmjs.org/@fastify/helmet/-/helmet-13.0.1.tgz",
-      "integrity": "sha512-i+ifqazG3d0HwHL3zuZdg6B/WPc9Ee6kVfGpwGho4nxm0UaK1htss0zq+1rVhOoAorZlCgTZ3/i4S58hUGkkoA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/fastify"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/fastify"
-        }
-      ],
+      "version": "12.0.1",
+      "resolved": "https://registry.npmjs.org/@fastify/helmet/-/helmet-12.0.1.tgz",
+      "integrity": "sha512-kkjBcedWwdflRThovGuvN9jB2QQLytBqArCFPdMIb7o2Fp0l/H3xxYi/6x/SSRuH/FFt9qpTGIfJz2bfnMrLqA==",
       "license": "MIT",
       "dependencies": {
         "fastify-plugin": "^5.0.0",
-        "helmet": "^8.0.0"
+        "helmet": "^7.1.0"
       }
     },
     "node_modules/@fastify/helmet/node_modules/fastify-plugin": {
@@ -1206,12 +1196,12 @@
       }
     },
     "node_modules/helmet": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/helmet/-/helmet-8.1.0.tgz",
-      "integrity": "sha512-jOiHyAZsmnr8LqoPGmCjYAaiuWwjAPLgY8ZX2XrmHawt99/u1y6RgrZMTeoPfpUbV96HOalYgz1qzkRbw54Pmg==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/helmet/-/helmet-7.2.0.tgz",
+      "integrity": "sha512-ZRiwvN089JfMXokizgqEPXsl2Guk094yExfoDXR0cBYWxtBbaSww/w+vT4WEJsBW2iTUi1GgZ6swmoug3Oy4Xw==",
       "license": "MIT",
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/help-me": {

--- a/app/middleware/package.json
+++ b/app/middleware/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@fastify/cors": "^9.0.1",
-    "@fastify/helmet": "^13.0.1",
+    "@fastify/helmet": "^12.0.0",
     "@fastify/rate-limit": "^10.3.0",
     "@fastify/sensible": "^4.1.0",
     "@fastify/type-provider-typebox": "^5.0.0",


### PR DESCRIPTION
## Summary
- downgrade `@fastify/helmet` to the Fastify v4-compatible major
- refresh the middleware lockfile to capture the dependency change
- log the emergency middleware recovery in the changelog

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d5b86536ec83339be10f4ac4ad0e29