### PR TITLE
Fix Fastify helmet plugin mismatch in middleware stack

### DIFF
--- a/Changelog/Changelog.md
+++ b/Changelog/Changelog.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.00.030] Middleware Helmet Downgrade
+- **Change Type:** Emergency Change
+- **Reason:** The middleware Docker container failed at runtime because `@fastify/helmet` v12 demands Fastify v5 while the stack still ships Fastify v4, halting the service during startup.
+- **What Changed:** Pinned `@fastify/helmet` to the Fastify v4-compatible v11 line, refreshed the npm lockfile, documented the troubleshooting step in the README, and confirmed the TypeScript build succeeds with the adjusted dependency set.
+
 ## [0.00.029] Fake Company Seed Unblock
 - **Change Type:** Normal Change
 - **Reason:** The maintenance script stalled because PostgreSQL waited for the synchronous replica to acknowledge commits while it was still warming up.

--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Both `install` and `update` wait for the PostgreSQL primary to become ready, see
 
 ### Troubleshooting
 - **Frontend port already in use:** Use `FRONTEND_DEV_PORT` (for `npm run dev`), `FRONTEND_PREVIEW_PORT` (for `npm run preview`), `FRONTEND_WEB_PORT` (for the standalone Compose stack), or `MIDDLEWARE_FRONTEND_WEB_PORT` (for the middleware stack) to remap the host port when `5173/5174` are occupied.
+- **Middleware container fails with a Fastify plugin mismatch:** Ensure dependencies are installed from the repository lockfile (`cd app/middleware && npm install`) so `@fastify/helmet` stays on the Fastify 4-compatible release line used by the Docker image.
 - **Stockmarket port already in use:** Set `STOCKMARKET_WEB_PORT` before running `docker compose -f stockmarket-compose.yml up --build` to relocate the simulator from `8100` to an available host port.
 
 ## Data Store Stack

--- a/app/middleware/package-lock.json
+++ b/app/middleware/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@fastify/cors": "^9.0.1",
-        "@fastify/helmet": "^12.0.0",
+        "@fastify/helmet": "^11.1.1",
         "@fastify/rate-limit": "^10.3.0",
         "@fastify/sensible": "^4.1.0",
         "@fastify/type-provider-typebox": "^5.0.0",
@@ -508,20 +508,14 @@
       }
     },
     "node_modules/@fastify/helmet": {
-      "version": "12.0.1",
-      "resolved": "https://registry.npmjs.org/@fastify/helmet/-/helmet-12.0.1.tgz",
-      "integrity": "sha512-kkjBcedWwdflRThovGuvN9jB2QQLytBqArCFPdMIb7o2Fp0l/H3xxYi/6x/SSRuH/FFt9qpTGIfJz2bfnMrLqA==",
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/@fastify/helmet/-/helmet-11.1.1.tgz",
+      "integrity": "sha512-pjJxjk6SLEimITWadtYIXt6wBMfFC1I6OQyH/jYVCqSAn36sgAIFjeNiibHtifjCd+e25442pObis3Rjtame6A==",
       "license": "MIT",
       "dependencies": {
-        "fastify-plugin": "^5.0.0",
-        "helmet": "^7.1.0"
+        "fastify-plugin": "^4.2.1",
+        "helmet": "^7.0.0"
       }
-    },
-    "node_modules/@fastify/helmet/node_modules/fastify-plugin": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/fastify-plugin/-/fastify-plugin-5.0.1.tgz",
-      "integrity": "sha512-HCxs+YnRaWzCl+cWRYFnHmeRFyR5GVnJTAaCJQiYzQSDwK9MgJdyAsuL3nh0EWRCYMgQ5MeziymvmAhUHYHDUQ==",
-      "license": "MIT"
     },
     "node_modules/@fastify/merge-json-schemas": {
       "version": "0.1.1",

--- a/app/middleware/package.json
+++ b/app/middleware/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@fastify/cors": "^9.0.1",
-    "@fastify/helmet": "^12.0.0",
+    "@fastify/helmet": "^11.1.1",
     "@fastify/rate-limit": "^10.3.0",
     "@fastify/sensible": "^4.1.0",
     "@fastify/type-provider-typebox": "^5.0.0",


### PR DESCRIPTION
## Summary
- downgrade @fastify/helmet to the Fastify v4-compatible 11.x line and refresh the lockfile
- document the plugin compatibility note in the README troubleshooting section
- log the emergency fix in the changelog with build verification details

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d626697dec8333889eb3c43e66983c