### PR TITLE
docs: add delivery roadmap for upcoming work

### DIFF
--- a/Changelog/Changelog.md
+++ b/Changelog/Changelog.md
@@ -1,5 +1,10 @@
 # Changelog
 
+# [0.00.033] Delivery Roadmap Foundation
+- **Change Type:** Standard Change
+- **Reason:** Capture the prioritized follow-up work requested after reviewing the current implementation against the published documentation.
+- **What Changed:** Authored a delivery roadmap outlining phased tasks across middleware, datastore integrations, frontend modernization, and simulator scaling, and linked the plan from the README so contributors can discover the next steps quickly.
+
 # [0.00.032] Middleware Datastore Wiring Repair
 - **Change Type:** Emergency Change
 - **Reason:** The middleware container crashed because it attempted to reach PostgreSQL at `127.0.0.1:5432`, leaving the stack without a database connection and producing repeated boot failures alongside Docker network reuse warnings.

--- a/README.md
+++ b/README.md
@@ -35,6 +35,9 @@ Both `install` and `update` wait for the PostgreSQL primary to become ready, see
 - **Multi-user economy** where players manage personal accounts while Game Masters steward the world through privileged tooling.
 - **Dynamic stock market sandbox** with AI-driven price regimes, sector indices, and fair-play trading mechanics.
 
+## Roadmap & Next Steps
+Track the active delivery plan in [`docs/roadmap/next-steps.md`](docs/roadmap/next-steps.md). The roadmap focuses on hardening the middleware foundations first, then connecting the datastore and stockmarket services, modernizing the frontend to consume live data, and finally scaling the simulator alongside cross-cutting security and operations initiatives.
+
 ## Frontend Experience
 - **Technology stack:** React + TypeScript + Vite with React Query and Zustand managing optimistic data flows.
 - **Feature highlights:** Guided onboarding journey, real-time dashboard metrics, celebratory transfer wizard, market desk heatmaps, and Game Master governance console.

--- a/docs/roadmap/next-steps.md
+++ b/docs/roadmap/next-steps.md
@@ -1,0 +1,42 @@
+# VirtualBank Delivery Plan
+
+This roadmap translates the documentation gaps into actionable workstreams so contributors can bring the simulator in line with the published blueprints.
+
+## Guiding Principles
+- **Documentation-first:** Align each milestone with the architecture and UX documents, updating them as capabilities land.
+- **Safety before spectacle:** Implement authentication, observability, and data durability ahead of advanced gameplay loops.
+- **Incremental integration:** Expand the middleware outward—first to the datastore, then the stockmarket, and finally to external channels.
+
+## Phase 1 – Middleware Foundations
+1. **Durable idempotency store** – Back idempotency keys with PostgreSQL or Redis and add replay protection hooks.
+2. **Datastore-backed workflows** – Replace the stub transfer/credit/order handlers with transactions and sagas that persist domain records.
+3. **Authentication shell** – Introduce session validation, API keys, and RBAC scaffolding ahead of full IAM integration.
+4. **Observability baseline** – Instrument structured logs, metrics, and traces, plus hardened error handling for each route.
+
+## Phase 2 – Data & Integration Layer
+1. **Prisma/SQL schema implementation** – Materialize the documented schema and generate typed accessors.
+2. **Event streaming bridge** – Publish Kafka topics for transfers, credits, market orders, and session events.
+3. **Cache tier wiring** – Layer Redis caching for hot reads and invalidation flows.
+4. **Stockmarket contract** – Formalize REST/WebSocket clients in the middleware for quote intake and order routing.
+
+## Phase 3 – Frontend Experience
+1. **API-powered stores** – Replace fixture-driven Zustand state with React Query fetching from live middleware endpoints.
+2. **Real-time dashboards** – Subscribe to WebSocket streams for portfolio, market depth, and session telemetry.
+3. **Validation and error UX** – Add optimistic updates, rollback handling, and user-facing error guidance per blueprint.
+4. **Design system hardening** – Introduce theming tokens, Storybook, and accessibility audits.
+
+## Phase 4 – Stockmarket Simulator
+1. **Service decomposition** – Split matching, pricing, risk, and analytics into dedicated modules/services.
+2. **Persistent storage** – Move portfolios, orders, and ticks into PostgreSQL/Redis for durability.
+3. **Risk feedback loop** – Emit risk events to middleware and adjust order intake based on credit signals.
+4. **Analytics pipeline** – Stream tick/portfolio snapshots into ClickHouse for dashboards.
+
+## Cross-Cutting Initiatives
+- **Security hardening** – TLS everywhere, anomaly detection hooks, and admin console protections.
+- **Operational tooling** – GitHub workflows, container scans, synthetic monitoring, and runbooks.
+- **Documentation upkeep** – Refresh READMEs, blueprints, and API references as features mature.
+
+## Immediate Next Steps
+- Prioritize Phase 1 tasks, beginning with durable idempotency storage and persistence-backed transfer flows.
+- Draft technical spikes for authentication and observability to estimate effort.
+- Schedule alignment reviews after each phase to revisit documentation and adjust priorities.


### PR DESCRIPTION
## Summary
- add a delivery roadmap that converts the documented gaps into phased middleware, integration, frontend, and simulator tasks
- link the roadmap from the README to surface the plan for contributors and log the update in the changelog

## Testing
- not run (documentation-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68d62c42f56c8333b4a71ccf609fd03a