### PR TITLE
Add connectivity automation script and env overrides

### DIFF
--- a/Changelog/Changelog.md
+++ b/Changelog/Changelog.md
@@ -1,5 +1,10 @@
 # Changelog
 
+# [0.00.038] API Connectivity Automation
+- **Change Type:** Normal Change
+- **Reason:** Provide a turnkey way to generate aligned API credentials and confirm cross-service connectivity so teams can bring up the stack without manual key choreography.
+- **What Changed:** Added the `scripts/connectivity.sh` helper to mint shared secrets, write environment overlays, and validate middleware/stockmarket/frontend endpoints; taught Compose stacks to honour injected auth variables; refreshed the README with the new workflow; and documented the improvement here.
+
 # [0.00.037] Stockmarket Simulator Phase 4 Delivery
 - **Change Type:** Normal Change
 - **Reason:** Implement Phase 4 of the delivery roadmap so the stockmarket simulator gains modular services, durable storage, risk governance, and analytics parity with the documented architecture.

--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@ VirtualBank is a playful online banking simulator for exploring modern money-man
 5. Launch the data store foundation locally with `docker compose -f apps/datastore/datastore-compose.yml up --build` when you want PostgreSQL, Redis, Kafka, ClickHouse, and MinIO services that mirror the reference architecture. Host bindings avoid common developer ports (`15432/15433` for PostgreSQL and `19000` for the ClickHouse native wire) so local installations stay untouched. The maintenance script automatically seeds the `market_companies` table from [`docs/dataset/fake_companies.json`](docs/dataset/fake_companies.json) once PostgreSQL reports healthy and temporarily downgrades synchronous commit so the seed finishes even if the replica is still starting.
 6. Explore the design blueprints in [`docs/designing/design.md`](docs/designing/design.md) to understand the planned player journeys and backend integrations.
 
+## API Connectivity Automation
+
+Run `./scripts/connectivity.sh` from the repository root to provision aligned API credentials for every service. The helper writes `connection.env` for Compose and component-scoped `.env.connection` files, checks the middleware and stockmarket health probes, and exercises an authenticated middleware endpoint to confirm the generated key works. Re-run with `--force` to overwrite existing files or `--deep-check` for a readiness probe, then launch stacks with `docker compose --env-file connection.env -f middleware-compose.yml up --build` to apply the shared configuration.
+
 ## Automated Maintenance
 The `scripts/maintenance.sh` helper orchestrates installation and lifecycle tasks for production-like environments. Execute the script as `root` (or with `sudo`) and pass one of the following commands:
 

--- a/frontend-compose.yml
+++ b/frontend-compose.yml
@@ -8,5 +8,9 @@ services:
       - "${FRONTEND_WEB_PORT:-5173}:5173"
     environment:
       NODE_ENV: production
+      VITE_MIDDLEWARE_BASE_URL: "${VITE_MIDDLEWARE_BASE_URL:-http://localhost:8080}"
+      VITE_MIDDLEWARE_API_KEY: "${VITE_MIDDLEWARE_API_KEY:-sandbox-secret}"
+      VITE_MIDDLEWARE_API_KEY_HEADER: "${VITE_MIDDLEWARE_API_KEY_HEADER:-x-api-key}"
+      VITE_MIDDLEWARE_SESSION_HEADER: "${VITE_MIDDLEWARE_SESSION_HEADER:-x-session-id}"
     command: npm run preview -- --host 0.0.0.0 --port 5173
     restart: unless-stopped

--- a/middleware-compose.yml
+++ b/middleware-compose.yml
@@ -13,8 +13,11 @@ services:
       RATE_LIMIT_MAX: 200
       RATE_LIMIT_TIME_WINDOW: 1 minute
       IDEMPOTENCY_TTL_SECONDS: 600
-      PUBLIC_BASE_URL: http://localhost:8080
-      STOCKMARKET_BASE_URL: http://vb-stockmarket:8100
+      PUBLIC_BASE_URL: "${MIDDLEWARE_PUBLIC_BASE_URL:-http://localhost:8080}"
+      STOCKMARKET_BASE_URL: "${MIDDLEWARE_STOCKMARKET_BASE_URL:-http://vb-stockmarket:8100}"
+      AUTH_API_KEYS: "${AUTH_API_KEYS:-}"
+      AUTH_API_KEY_HEADER: "${AUTH_API_KEY_HEADER:-x-api-key}"
+      AUTH_SESSION_HEADER: "${AUTH_SESSION_HEADER:-x-session-id}"
       DATASTORE_HOST: postgres-primary
       DATASTORE_PORT: 5432
       DATASTORE_USER: vb_app

--- a/scripts/connectivity.sh
+++ b/scripts/connectivity.sh
@@ -1,0 +1,314 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage: ./scripts/connectivity.sh [options]
+
+Generate shared API credentials for the VirtualBank services, write local
+configuration files, and verify that the primary HTTP endpoints are reachable.
+
+Options:
+  --middleware-url <url>   Middleware base URL (default: http://localhost:8080)
+  --frontend-url <url>     Frontend base URL (default: http://localhost:5173)
+  --stockmarket-url <url>  Stockmarket base URL (default: http://localhost:8100)
+  --api-key-id <id>        API key identifier (default: automation-service)
+  --api-key <secret>       API key secret (random when omitted)
+  --api-key-header <name>  API key header name (default: x-api-key)
+  --session-header <name>  Session header name (default: x-session-id)
+  --force                  Overwrite existing connection files
+  --deep-check             Attempt authenticated middleware endpoints (may fail
+                           if datastores are offline)
+  -h, --help               Show this help message
+USAGE
+}
+
+log() { printf '[%(%Y-%m-%dT%H:%M:%S%z)T] %s\n' -1 "$*"; }
+warn() { log "WARN: $*"; }
+error() { log "ERROR: $*" >&2; }
+
+require_command() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    error "Required command '$1' not found. $2"
+    exit 1
+  fi
+}
+
+strip_trailing_slash() {
+  local value="$1"
+  while [[ "$value" == */ && "$value" != "http://" && "$value" != "https://" ]]; do
+    value="${value%/}"
+  done
+  printf '%s' "$value"
+}
+
+generate_secret() {
+  if command -v python3 >/dev/null 2>&1; then
+    python3 - <<'PY'
+import secrets
+print(secrets.token_urlsafe(32))
+PY
+    return
+  fi
+  if command -v python >/dev/null 2>&1; then
+    python - <<'PY'
+import secrets
+print(secrets.token_urlsafe(32))
+PY
+    return
+  fi
+  if command -v openssl >/dev/null 2>&1; then
+    openssl rand -base64 32 | tr -d '\n'
+    return
+  fi
+  dd if=/dev/urandom bs=32 count=1 2>/dev/null | base64 | tr -d '\n'
+}
+
+generate_uuid() {
+  if command -v python3 >/dev/null 2>&1; then
+    python3 - <<'PY'
+import uuid
+print(uuid.uuid4())
+PY
+    return
+  fi
+  if command -v uuidgen >/dev/null 2>&1; then
+    uuidgen
+    return
+  fi
+  printf 'session-%s' "$(date +%s%N)"
+}
+
+check_endpoint() {
+  local name="$1"
+  local url="$2"
+  local required="$3"
+  shift 3
+  local tmp
+  tmp="$(mktemp)"
+  local http_code
+  if ! http_code="$(curl -sS -o "$tmp" -w '%{http_code}' "$@" "$url" 2>"${tmp}.err")"; then
+    http_code="000"
+  fi
+  local status=$((10#${http_code:-0}))
+  local body="$(<"$tmp")"
+  local err="$(<"${tmp}.err" 2>/dev/null || true)"
+  rm -f "$tmp" "${tmp}.err"
+
+  if (( status >= 200 && status < 300 )); then
+    log "✔ ${name} responded with HTTP ${status}"
+    return 0
+  fi
+
+  if [[ "$required" == "optional" && status -ne 0 ]]; then
+    warn "${name} returned HTTP ${status}. Response: ${body}"
+    return 0
+  fi
+
+  error "${name} check failed (HTTP ${status}). Response: ${body}${err:+ | ${err}}"
+  exit 1
+}
+
+check_protected_endpoint() {
+  local url="$1"
+  local api_header="$2"
+  local api_secret="$3"
+  local session_header="$4"
+  local session_id="$5"
+  local description="$6"
+  local tmp
+  tmp="$(mktemp)"
+  local http_code
+  if ! http_code="$(curl -sS -o "$tmp" -w '%{http_code}' -H "${api_header}: ${api_secret}" -H "${session_header}: ${session_id}" "$url" 2>"${tmp}.err")"; then
+    http_code="000"
+  fi
+  local status=$((10#${http_code:-0}))
+  local body="$(<"$tmp")"
+  local err="$(<"${tmp}.err" 2>/dev/null || true)"
+  rm -f "$tmp" "${tmp}.err"
+
+  case $status in
+    200|202|204|400|404|409)
+      log "✔ ${description} responded with HTTP ${status}"
+      ;;
+    401|403)
+      error "${description} rejected the generated credentials (HTTP ${status}). Response: ${body}"
+      exit 1
+      ;;
+    0)
+      error "${description} request failed: ${body}${err:+ | ${err}}"
+      exit 1
+      ;;
+    *)
+      warn "${description} returned HTTP ${status}. Response: ${body}"
+      ;;
+  esac
+}
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+MIDDLEWARE_URL="http://localhost:8080"
+FRONTEND_URL="http://localhost:5173"
+STOCKMARKET_URL="http://localhost:8100"
+API_KEY_ID="automation-service"
+API_KEY_SECRET=""
+API_KEY_HEADER="x-api-key"
+SESSION_HEADER="x-session-id"
+FORCE=0
+DEEP_CHECK=0
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --middleware-url)
+      MIDDLEWARE_URL="$2"
+      shift 2
+      ;;
+    --frontend-url)
+      FRONTEND_URL="$2"
+      shift 2
+      ;;
+    --stockmarket-url)
+      STOCKMARKET_URL="$2"
+      shift 2
+      ;;
+    --api-key-id)
+      API_KEY_ID="$2"
+      shift 2
+      ;;
+    --api-key)
+      API_KEY_SECRET="$2"
+      shift 2
+      ;;
+    --api-key-header)
+      API_KEY_HEADER="$2"
+      shift 2
+      ;;
+    --session-header)
+      SESSION_HEADER="$2"
+      shift 2
+      ;;
+    --force)
+      FORCE=1
+      shift
+      ;;
+    --deep-check)
+      DEEP_CHECK=1
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      error "Unknown option: $1"
+      usage
+      exit 1
+      ;;
+  esac
+done
+
+require_command curl "Install curl to probe service endpoints."
+
+if [[ -z "$API_KEY_SECRET" ]]; then
+  API_KEY_SECRET="$(generate_secret)"
+  log "Generated API secret for '${API_KEY_ID}'."
+fi
+
+MIDDLEWARE_URL="$(strip_trailing_slash "$MIDDLEWARE_URL")"
+FRONTEND_URL="$(strip_trailing_slash "$FRONTEND_URL")"
+STOCKMARKET_URL="$(strip_trailing_slash "$STOCKMARKET_URL")"
+
+ROLES="bank:transfers:read|bank:transfers:write|bank:credits:write|market:orders:write|sessions:stream:subscribe|system:metrics:read"
+AUTH_API_KEYS_VALUE="${API_KEY_ID}:${API_KEY_SECRET}:${ROLES}"
+
+stock_ws_scheme="${STOCKMARKET_URL%%://*}"
+stock_ws_suffix="${STOCKMARKET_URL#*://}"
+case "$stock_ws_scheme" in
+  http)
+    STOCKMARKET_WS_URL="ws://${stock_ws_suffix%/}/ws/ticks"
+    ;;
+  https)
+    STOCKMARKET_WS_URL="wss://${stock_ws_suffix%/}/ws/ticks"
+    ;;
+  ws|wss)
+    STOCKMARKET_WS_URL="${STOCKMARKET_URL%/}/ws/ticks"
+    ;;
+  *)
+    STOCKMARKET_WS_URL="${STOCKMARKET_URL%/}/ws/ticks"
+    ;;
+esac
+
+ROOT_ENV_FILE="${ROOT_DIR}/connection.env"
+MW_ENV_FILE="${ROOT_DIR}/app/middleware/.env.connection"
+FRONTEND_ENV_FILE="${ROOT_DIR}/app/frontend/.env.connection"
+STOCKMARKET_ENV_FILE="${ROOT_DIR}/app/stockmarket/.env.connection"
+
+maybe_overwrite() {
+  local file="$1"
+  if [[ -f "$file" && $FORCE -eq 0 ]]; then
+    error "File '$file' already exists. Re-run with --force to overwrite."
+    exit 1
+  fi
+}
+
+maybe_overwrite "$ROOT_ENV_FILE"
+maybe_overwrite "$MW_ENV_FILE"
+maybe_overwrite "$FRONTEND_ENV_FILE"
+maybe_overwrite "$STOCKMARKET_ENV_FILE"
+
+cat >"$ROOT_ENV_FILE" <<EOF
+# Autogenerated by scripts/connectivity.sh on $(date -u +%Y-%m-%dT%H:%M:%SZ)
+AUTH_API_KEYS="${AUTH_API_KEYS_VALUE}"
+AUTH_API_KEY_HEADER="${API_KEY_HEADER}"
+AUTH_SESSION_HEADER="${SESSION_HEADER}"
+MIDDLEWARE_PUBLIC_BASE_URL="${MIDDLEWARE_URL}"
+MIDDLEWARE_STOCKMARKET_BASE_URL="${STOCKMARKET_URL}"
+VITE_MIDDLEWARE_BASE_URL="${MIDDLEWARE_URL}"
+VITE_MIDDLEWARE_API_KEY="${API_KEY_SECRET}"
+VITE_MIDDLEWARE_API_KEY_HEADER="${API_KEY_HEADER}"
+VITE_MIDDLEWARE_SESSION_HEADER="${SESSION_HEADER}"
+STOCKMARKET_MIDDLEWARE_BASE_URL="${MIDDLEWARE_URL}"
+EOF
+
+cat >"$MW_ENV_FILE" <<EOF
+# Autogenerated by scripts/connectivity.sh on $(date -u +%Y-%m-%dT%H:%M:%SZ)
+AUTH_API_KEYS="${AUTH_API_KEYS_VALUE}"
+AUTH_API_KEY_HEADER="${API_KEY_HEADER}"
+AUTH_SESSION_HEADER="${SESSION_HEADER}"
+PUBLIC_BASE_URL="${MIDDLEWARE_URL}"
+STOCKMARKET_BASE_URL="${STOCKMARKET_URL}"
+STOCKMARKET_WS_URL="${STOCKMARKET_WS_URL}"
+EOF
+
+cat >"$FRONTEND_ENV_FILE" <<EOF
+# Autogenerated by scripts/connectivity.sh on $(date -u +%Y-%m-%dT%H:%M:%SZ)
+VITE_MIDDLEWARE_BASE_URL="${MIDDLEWARE_URL}"
+VITE_MIDDLEWARE_API_KEY="${API_KEY_SECRET}"
+VITE_MIDDLEWARE_API_KEY_HEADER="${API_KEY_HEADER}"
+VITE_MIDDLEWARE_SESSION_HEADER="${SESSION_HEADER}"
+EOF
+
+cat >"$STOCKMARKET_ENV_FILE" <<EOF
+# Autogenerated by scripts/connectivity.sh on $(date -u +%Y-%m-%dT%H:%M:%SZ)
+STOCKMARKET_MIDDLEWARE_BASE_URL="${MIDDLEWARE_URL}"
+EOF
+
+chmod 600 "$ROOT_ENV_FILE" "$MW_ENV_FILE" "$FRONTEND_ENV_FILE" "$STOCKMARKET_ENV_FILE" 2>/dev/null || true
+
+log "Wrote connection environment files:"
+log "  - ${ROOT_ENV_FILE}"
+log "  - ${MW_ENV_FILE}"
+log "  - ${FRONTEND_ENV_FILE}"
+log "  - ${STOCKMARKET_ENV_FILE}"
+
+check_endpoint "Middleware live probe" "${MIDDLEWARE_URL}/health/live" required
+check_endpoint "Stockmarket live probe" "${STOCKMARKET_URL}/health/live" optional
+check_endpoint "Frontend availability" "${FRONTEND_URL}" optional -L
+
+SESSION_TOKEN="$(generate_uuid)"
+check_protected_endpoint "${MIDDLEWARE_URL}/api/v1/transfers/__connection-check" "${API_KEY_HEADER}" "${API_KEY_SECRET}" "${SESSION_HEADER}" "${SESSION_TOKEN}" "Protected middleware request"
+
+if (( DEEP_CHECK )); then
+  check_endpoint "Middleware readiness" "${MIDDLEWARE_URL}/health/ready" required
+fi
+
+log "Connection checks completed. Use 'docker compose --env-file connection.env -f middleware-compose.yml up --build' to launch the stack with the generated credentials."


### PR DESCRIPTION
## Summary
- add a connectivity automation script that generates shared API credentials, writes env overlays, and validates service reachability
- allow the compose stacks to read injected authentication variables and document the workflow in the README
- record the update in the changelog

## Testing
- bash -n scripts/connectivity.sh

------
https://chatgpt.com/codex/tasks/task_e_68d64aa8b7248333ac0660f83e388e14