### PR TITLE
Force maintenance rebuilds to refresh connectivity

### DIFF
--- a/Changelog/Changelog.md
+++ b/Changelog/Changelog.md
@@ -1,5 +1,10 @@
 # Changelog
 
+# [0.00.041] Forced Container Rebuilds For Connectivity
+- **Change Type:** Emergency Change
+- **Reason:** Provisioned API credentials were not reaching running containers, leaving the frontend unable to authenticate with the middleware after maintenance runs.
+- **What Changed:** Updated `scripts/maintenance.sh` to tear down each Compose stack, rebuild images without cache, and recreate containers with `--force-recreate`, refreshed the README to highlight the new zero-cache rebuild behaviour, and documented the fix here.
+
 # [0.00.040] Maintenance Connectivity Orchestration
 - **Change Type:** Normal Change
 - **Reason:** Ensure API credentials are provisioned automatically and containers start in a reliable order during unattended maintenance runs.

--- a/README.md
+++ b/README.md
@@ -23,14 +23,14 @@ The `scripts/maintenance.sh` helper orchestrates installation and lifecycle task
 
 | Command | Description |
 | --- | --- |
-| `install` | Clones the upstream repository into `/opt/VirtualBank`, verifies Docker tooling, generates shared API credentials, and starts the datastore → stockmarket → middleware stacks with shared networks. |
-| `update` | Pulls the latest commits, refreshes shared API credentials, rebuilds containers, and reapplies the datastore → stockmarket → middleware stacks. |
+| `install` | Clones the upstream repository into `/opt/VirtualBank`, verifies Docker tooling, generates shared API credentials, and starts the datastore → stockmarket → middleware stacks with shared networks. Every stack is recreated after a `down` + no-cache `build` so fresh environment variables propagate. |
+| `update` | Pulls the latest commits, refreshes shared API credentials, forces no-cache rebuilds of every container, and reapplies the datastore → stockmarket → middleware stacks so new middleware/stockmarket configuration is honoured immediately. |
 | `uninstall` | Stops active Compose services, removes related volumes, and deletes `/opt/VirtualBank`. |
 | `check-updates` | Contacts GitHub to determine whether newer commits are available without applying changes. |
 
 Example usage: `sudo ./scripts/maintenance.sh install`.
 
-Both `install` and `update` wait for the datastore services to report healthy, seed the `market_companies` table, rehydrate the shared connectivity bundle, and confirm the middleware/frontend probes succeed before reporting success. The seed runs with `synchronous_commit=local` so it never blocks on a cold replica while the dataset is applied.
+Both `install` and `update` wait for the datastore services to report healthy, seed the `market_companies` table, rehydrate the shared connectivity bundle, and confirm the middleware/frontend probes succeed before reporting success. Each run tears down the running containers first and rebuilds images without cache, guaranteeing that regenerated API keys and Compose environment overrides flow into the restarted services. The seed runs with `synchronous_commit=local` so it never blocks on a cold replica while the dataset is applied.
 
 ## Highlights
 - **Best-in-class UX** with responsive, accessible interfaces and gamified feedback loops.

--- a/scripts/maintenance.sh
+++ b/scripts/maintenance.sh
@@ -355,9 +355,13 @@ rebuild_stack() {
   if [[ -f "${INSTALL_DIR}/${DATASTORE_COMPOSE}" ]]; then
     log "Ensuring datastore stack is prepared using ${compose_cmd}."
     (cd "$INSTALL_DIR" && $compose_cmd -f "$DATASTORE_COMPOSE" pull)
-    if ! (cd "$INSTALL_DIR" && $compose_cmd -f "$DATASTORE_COMPOSE" up -d --build --wait); then
+    log "Tearing down datastore containers to guarantee a clean rebuild."
+    (cd "$INSTALL_DIR" && $compose_cmd -f "$DATASTORE_COMPOSE" down --remove-orphans)
+    log "Rebuilding datastore images without cache (pulling fresh bases)."
+    (cd "$INSTALL_DIR" && $compose_cmd -f "$DATASTORE_COMPOSE" build --pull --no-cache)
+    if ! (cd "$INSTALL_DIR" && $compose_cmd -f "$DATASTORE_COMPOSE" up -d --force-recreate --remove-orphans --wait); then
       warn "Compose '--wait' unsupported for datastore stack; retrying without it."
-      (cd "$INSTALL_DIR" && $compose_cmd -f "$DATASTORE_COMPOSE" up -d --build)
+      (cd "$INSTALL_DIR" && $compose_cmd -f "$DATASTORE_COMPOSE" up -d --force-recreate --remove-orphans)
     fi
     if ! wait_for_container_ready "$POSTGRES_PRIMARY_CONTAINER" 240; then
       warn "PostgreSQL primary did not report healthy before timeout."
@@ -385,9 +389,13 @@ rebuild_stack() {
   if [[ -f "${INSTALL_DIR}/${STOCKMARKET_COMPOSE}" ]]; then
     log "Ensuring stockmarket stack is prepared using ${compose_cmd}."
     (cd "$INSTALL_DIR" && $compose_cmd "${env_args[@]}" -f "$STOCKMARKET_COMPOSE" pull)
-    if ! (cd "$INSTALL_DIR" && $compose_cmd "${env_args[@]}" -f "$STOCKMARKET_COMPOSE" up -d --build --wait); then
+    log "Tearing down stockmarket containers to guarantee a clean rebuild."
+    (cd "$INSTALL_DIR" && $compose_cmd "${env_args[@]}" -f "$STOCKMARKET_COMPOSE" down --remove-orphans)
+    log "Rebuilding stockmarket images without cache (pulling fresh bases)."
+    (cd "$INSTALL_DIR" && $compose_cmd "${env_args[@]}" -f "$STOCKMARKET_COMPOSE" build --pull --no-cache)
+    if ! (cd "$INSTALL_DIR" && $compose_cmd "${env_args[@]}" -f "$STOCKMARKET_COMPOSE" up -d --force-recreate --remove-orphans --wait); then
       warn "Compose '--wait' unsupported for stockmarket stack; retrying without it."
-      (cd "$INSTALL_DIR" && $compose_cmd "${env_args[@]}" -f "$STOCKMARKET_COMPOSE" up -d --build)
+      (cd "$INSTALL_DIR" && $compose_cmd "${env_args[@]}" -f "$STOCKMARKET_COMPOSE" up -d --force-recreate --remove-orphans)
     fi
     if ! wait_for_container_ready "vb-stockmarket" 180; then
       warn "Stockmarket simulator did not report ready before timeout."
@@ -399,9 +407,13 @@ rebuild_stack() {
   if [[ -f "${INSTALL_DIR}/${COMPOSE_FILE}" ]]; then
     log "Updating middleware stack using ${compose_cmd}."
     (cd "$INSTALL_DIR" && $compose_cmd "${env_args[@]}" -f "$COMPOSE_FILE" pull)
-    if ! (cd "$INSTALL_DIR" && $compose_cmd "${env_args[@]}" -f "$COMPOSE_FILE" up -d --build --wait); then
+    log "Tearing down middleware containers to guarantee a clean rebuild."
+    (cd "$INSTALL_DIR" && $compose_cmd "${env_args[@]}" -f "$COMPOSE_FILE" down --remove-orphans)
+    log "Rebuilding middleware images without cache (pulling fresh bases)."
+    (cd "$INSTALL_DIR" && $compose_cmd "${env_args[@]}" -f "$COMPOSE_FILE" build --pull --no-cache)
+    if ! (cd "$INSTALL_DIR" && $compose_cmd "${env_args[@]}" -f "$COMPOSE_FILE" up -d --force-recreate --remove-orphans --wait); then
       warn "Compose '--wait' unsupported for middleware stack; retrying without it."
-      (cd "$INSTALL_DIR" && $compose_cmd "${env_args[@]}" -f "$COMPOSE_FILE" up -d --build)
+      (cd "$INSTALL_DIR" && $compose_cmd "${env_args[@]}" -f "$COMPOSE_FILE" up -d --force-recreate --remove-orphans)
     fi
     local middleware_health_url frontend_url
     middleware_health_url="$(middleware_public_url)/health/live"


### PR DESCRIPTION
## Summary
- tear down each compose stack during maintenance, rebuild images without cache, and force container recreation so regenerated API credentials are picked up
- refresh the README automated maintenance section to document the new rebuild behaviour
- log the emergency fix in the changelog

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d6527d41808333ab6a9a2df1a76583