### PR TITLE
Fix datastore stack boot regressions

### DIFF
--- a/Changelog/Changelog.md
+++ b/Changelog/Changelog.md
@@ -1,5 +1,10 @@
 # Changelog
 
+# [0.00.046] Datastore Stack Boot Recovery
+- **Change Type:** Emergency Change
+- **Reason:** Maintenance rebuilds stalled because the PostgreSQL replica rejected startup without the legacy `POSTGRESQL_MASTER_*` variables, Kafka refused to format storage with the deprecated cluster ID, and MinIO's health probe fired before the service finished its warm-up cycle.
+- **What Changed:** Exported both legacy and modern PostgreSQL replication variables so the replica can locate the primary across Bitnami tag revisions, regenerated the Kafka KRaft cluster ID using a valid Base64URL value, extended the MinIO health-check start period, and refreshed the README with compatibility guidance for future overrides.
+
 # [0.00.045] Middleware Plugin Timeout Extension
 - **Change Type:** Emergency Change
 - **Reason:** Middleware restarts continued because Fastify aborted the datastore plugin while it was still creating indexes on large datasets, preventing the API from ever exposing its health probes.

--- a/README.md
+++ b/README.md
@@ -110,6 +110,10 @@ The `apps/datastore/datastore-compose.yml` stack mirrors the architecture define
 
 Bring the stack online with `docker compose -f apps/datastore/datastore-compose.yml up --build` and connect services using the shared `datastore-net` bridge network. Default credentials are scoped to local development and should be replaced in production-like scenarios.
 
+> **Replica compatibility:** The Bitnami PostgreSQL images recently reverted to the legacy `POSTGRESQL_MASTER_*` variables. The Compose file now exports both the legacy and modern `POSTGRESQL_PRIMARY_*` values so maintenance rebuilds succeed regardless of the tag that ships during an update. If you override the host or credentials, update both aliases (or set them through an `.env` file) so the replica continues to locate the primary.
+>
+> **Kafka KRaft tip:** Kafka requires a valid Base64URL cluster ID when formatting its metadata directory. The bundled stack ships with a generated ID, and you can mint a fresh value anytime with `python - <<'PY'` → `import base64, os; print(base64.urlsafe_b64encode(os.urandom(16)).decode().rstrip('='))` → `PY` before recreating volumes.
+
 ## Stockmarket Simulation Stack
 The `stockmarket-compose.yml` stack provides the executable market sandbox referenced throughout the design blueprint.
 

--- a/apps/datastore/datastore-compose.yml
+++ b/apps/datastore/datastore-compose.yml
@@ -41,10 +41,14 @@ services:
       - POSTGRESQL_REPLICATION_MODE=slave
       - POSTGRESQL_PRIMARY_HOST=postgres-primary
       - POSTGRESQL_PRIMARY_PORT_NUMBER=5432
+      - POSTGRESQL_MASTER_HOST=postgres-primary
+      - POSTGRESQL_MASTER_PORT_NUMBER=5432
       - POSTGRESQL_REPLICATION_USER=vb_repl
       - POSTGRESQL_REPLICATION_PASSWORD=vb_repl_password
       - POSTGRESQL_PRIMARY_USER=vb_app
       - POSTGRESQL_PRIMARY_PASSWORD=vb_app_password
+      - POSTGRESQL_MASTER_USER=vb_app
+      - POSTGRESQL_MASTER_PASSWORD=vb_app_password
       - ALLOW_EMPTY_PASSWORD=no
     volumes:
       - postgres-replica-data:/bitnami/postgresql
@@ -92,7 +96,7 @@ services:
       - KAFKA_CFG_NUM_PARTITIONS=3
       - KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP=CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT
       - ALLOW_PLAINTEXT_LISTENER=yes
-      - KAFKA_KRAFT_CLUSTER_ID=4L6g3nShT-eMCtK--X86w
+      - KAFKA_KRAFT_CLUSTER_ID=UyrxPpcZpVFK1ChhDpIdjA
     volumes:
       - kafka-data:/bitnami/kafka
     healthcheck:
@@ -141,6 +145,7 @@ services:
       interval: 30s
       timeout: 10s
       retries: 5
+      start_period: 60s
     networks:
       - datastore-net
 


### PR DESCRIPTION
## Summary
- add legacy PostgreSQL replication variables to keep the replica aligned with the primary
- regenerate the Kafka KRaft cluster id with a valid Base64URL token
- delay the MinIO health probe and document the compatibility updates in the README and changelog

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d67a6db0c0833398d45f70593d0548