### PR TITLE
Fix MinIO health check authentication

### DIFF
--- a/Changelog/Changelog.md
+++ b/Changelog/Changelog.md
@@ -1,5 +1,10 @@
 # Changelog
 
+# [0.00.047] MinIO Health Probe Authentication
+- **Change Type:** Emergency Change
+- **Reason:** The datastore maintenance runs and compose health checks reported MinIO as unhealthy because the S3 API blocked unauthenticated requests to the `/minio/health/live` endpoint.
+- **What Changed:** Updated the MinIO health check to authenticate with the configured root credentials so probes succeed and documented the behaviour in the README service table.
+
 # [0.00.046] Datastore Stack Boot Recovery
 - **Change Type:** Emergency Change
 - **Reason:** Maintenance rebuilds stalled because the PostgreSQL replica rejected startup without the legacy `POSTGRESQL_MASTER_*` variables, Kafka refused to format storage with the deprecated cluster ID, and MinIO's health probe fired before the service finished its warm-up cycle.

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ The `apps/datastore/datastore-compose.yml` stack mirrors the architecture define
 | Kafka broker | `9092` | PLAINTEXT listener for local event streaming. |
 | ClickHouse HTTP | `8123` | Default HTTP endpoint for queries and health checks. |
 | ClickHouse native | `19000` | Non-default host binding for the native protocol to prevent overlap with MinIO. |
-| MinIO API | `9000` | S3-compatible API surface. |
+| MinIO API | `9000` | S3-compatible API surface (health probes require the root credentials). |
 | MinIO console | `9001` | Web console for inspecting buckets and objects. |
 
 Bring the stack online with `docker compose -f apps/datastore/datastore-compose.yml up --build` and connect services using the shared `datastore-net` bridge network. Default credentials are scoped to local development and should be replaced in production-like scenarios.

--- a/apps/datastore/datastore-compose.yml
+++ b/apps/datastore/datastore-compose.yml
@@ -141,7 +141,11 @@ services:
     volumes:
       - minio-data:/data
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
+      test:
+        - "CMD-SHELL"
+        - >-
+          curl -fsS -u "$MINIO_ROOT_USER:$MINIO_ROOT_PASSWORD"
+          http://localhost:9000/minio/health/live || exit 1
       interval: 30s
       timeout: 10s
       retries: 5


### PR DESCRIPTION
## Summary
- authenticate the MinIO health probe with the configured root credentials so Compose reports the container healthy
- document the authentication requirement in the datastore service table and changelog

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d67e12cea88333af976f896ac5b1d6