### PR TITLE
Fix ledger schema backfill for middleware boot

### DIFF
--- a/Changelog/Changelog.md
+++ b/Changelog/Changelog.md
@@ -1,5 +1,10 @@
 # Changelog
 
+# [0.00.048] Ledger Schema Recovery
+- **Change Type:** Emergency Change
+- **Reason:** Middleware bootstraps failed because PostgreSQL instances created before the ledger schema refactor were missing the `account_id` column, so index creation aborted and the service never finished its startup.
+- **What Changed:** Added a defensive migration step that backfills the `ledger_entries.account_id` column when absent before rebuilding the related index, restoring middleware compatibility with existing databases.
+
 # [0.00.047] MinIO Health Probe Authentication
 - **Change Type:** Emergency Change
 - **Reason:** The datastore maintenance runs and compose health checks reported MinIO as unhealthy because the S3 API blocked unauthenticated requests to the `/minio/health/live` endpoint.

--- a/app/middleware/src/datastore/schema.ts
+++ b/app/middleware/src/datastore/schema.ts
@@ -52,6 +52,7 @@ const statements = [
       currency TEXT NOT NULL,
       occurred_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
     )`,
+  `ALTER TABLE ledger_entries ADD COLUMN IF NOT EXISTS account_id TEXT REFERENCES accounts(account_id) ON DELETE CASCADE`,
   `CREATE INDEX IF NOT EXISTS idx_ledger_entries_account ON ledger_entries (account_id)`,
   `CREATE TABLE IF NOT EXISTS credit_applications (
       application_id TEXT PRIMARY KEY,


### PR DESCRIPTION
## Summary
- ensure the middleware schema migration backfills the ledger_entries.account_id column before building its index
- document the emergency ledger schema recovery in the changelog

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d67f6842588333b16600232becdca6