### PR TITLE
Escape MinIO credentials in datastore health check

### DIFF
--- a/Changelog/Changelog.md
+++ b/Changelog/Changelog.md
@@ -1,5 +1,10 @@
 # Changelog
 
+# [0.00.049] MinIO Health Check Variable Escaping
+- **Change Type:** Normal Change
+- **Reason:** Docker Compose emitted warnings during installs because the MinIO health probe referenced root credential environment variables that Compose attempted to resolve from the host.
+- **What Changed:** Escaped the MinIO credential variables inside the health check command so it reads the container-scoped values without host interpolation warnings and documented the behaviour update in the README.
+
 # [0.00.048] Ledger Schema Recovery
 - **Change Type:** Emergency Change
 - **Reason:** Middleware bootstraps failed because PostgreSQL instances created before the ledger schema refactor were missing the `account_id` column, so index creation aborted and the service never finished its startup.

--- a/README.md
+++ b/README.md
@@ -110,6 +110,8 @@ The `apps/datastore/datastore-compose.yml` stack mirrors the architecture define
 
 Bring the stack online with `docker compose -f apps/datastore/datastore-compose.yml up --build` and connect services using the shared `datastore-net` bridge network. Default credentials are scoped to local development and should be replaced in production-like scenarios.
 
+The MinIO health check now authenticates with the bundled root credentials from inside the container, so `docker compose` no longer warns about blank `MINIO_ROOT_USER`/`MINIO_ROOT_PASSWORD` values even when you launch the stack with a custom `--env-file`.
+
 > **Replica compatibility:** The Bitnami PostgreSQL images recently reverted to the legacy `POSTGRESQL_MASTER_*` variables. The Compose file now exports both the legacy and modern `POSTGRESQL_PRIMARY_*` values so maintenance rebuilds succeed regardless of the tag that ships during an update. If you override the host or credentials, update both aliases (or set them through an `.env` file) so the replica continues to locate the primary.
 >
 > **Kafka KRaft tip:** Kafka requires a valid Base64URL cluster ID when formatting its metadata directory. The bundled stack ships with a generated ID, and you can mint a fresh value anytime with `python - <<'PY'` → `import base64, os; print(base64.urlsafe_b64encode(os.urandom(16)).decode().rstrip('='))` → `PY` before recreating volumes.

--- a/apps/datastore/datastore-compose.yml
+++ b/apps/datastore/datastore-compose.yml
@@ -144,7 +144,7 @@ services:
       test:
         - "CMD-SHELL"
         - >-
-          curl -fsS -u "$MINIO_ROOT_USER:$MINIO_ROOT_PASSWORD"
+          curl -fsS -u "$$MINIO_ROOT_USER:$$MINIO_ROOT_PASSWORD"
           http://localhost:9000/minio/health/live || exit 1
       interval: 30s
       timeout: 10s


### PR DESCRIPTION
## Summary
- escape the MinIO health probe credentials so Docker Compose no longer logs missing variable warnings during installs
- document the updated behaviour in the README and changelog entry

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d6804fb7c08333bedb32dbf4851346