### PR TITLE
Fix stockmarket order schema bootstrap

### DIFF
--- a/Changelog/Changelog.md
+++ b/Changelog/Changelog.md
@@ -1,5 +1,10 @@
 # Changelog
 
+# [0.00.052] Stockmarket Order Schema Recovery
+- **Change Type:** Emergency Change
+- **Reason:** The stockmarket container crashed during startup because historic PostgreSQL volumes lacked the `market_orders.user_id` column referenced by the matching engine, aborting the service before it exposed its API.
+- **What Changed:** Added a defensive schema migration that backfills the missing `user_id` column during storage initialisation and updated the README to explain the automatic recovery behaviour.
+
 # [0.00.051] Middleware Cache and Kafka Networking Fix
 - **Change Type:** Emergency Change
 - **Reason:** The middleware container defaulted to `localhost` for Redis and Kafka, causing repeated connection refusals inside Docker and leaving the stack without caching or event streaming.

--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ The `stockmarket-compose.yml` stack provides the executable market sandbox refer
 - **Networks:** Joins `virtualbank-backplane` (shared with middleware) and `virtualbank-datastore` so future datastore integrations do not require manual wiring.
 - **Configuration:** Tune tick cadence (`STOCKMARKET_TICK_INTERVAL`), news frequency (`STOCKMARKET_NEWS_INTERVAL`), dataset path, and host port (`STOCKMARKET_WEB_PORT`) purely through environment variables.
 - **Internals:** Pricing, matching, risk, and analytics services run as dedicated modules. Orders, portfolios, and tick snapshots persist to PostgreSQL/Redis while middleware-facing risk loops gate order intake and feed ClickHouse analytics.
+- **Startup recovery:** During boot the storage layer now backfills the historic `market_orders.user_id` column when it is missing so older PostgreSQL volumes remain compatible without manual SQL patches.
 
 | Service | Host Port | Notes |
 | --- | --- | --- |

--- a/app/stockmarket/src/storage.py
+++ b/app/stockmarket/src/storage.py
@@ -325,6 +325,25 @@ class StockmarketStorage:
         )
         await conn.execute(
             """
+            ALTER TABLE market_orders
+            ADD COLUMN IF NOT EXISTS user_id TEXT
+            """
+        )
+        await conn.execute(
+            """
+            UPDATE market_orders
+            SET user_id = 'legacy-user'
+            WHERE user_id IS NULL
+            """
+        )
+        await conn.execute(
+            """
+            ALTER TABLE market_orders
+            ALTER COLUMN user_id SET NOT NULL
+            """
+        )
+        await conn.execute(
+            """
             CREATE TABLE IF NOT EXISTS market_trades (
                 order_id TEXT NOT NULL,
                 counter_order_id TEXT,


### PR DESCRIPTION
## Summary
- add a defensive migration step that backfills the market_orders.user_id column during stockmarket storage initialisation
- document the automatic recovery path in the stockmarket README section
- record the emergency fix in the changelog

## Testing
- python -m compileall app/stockmarket/src

------
https://chatgpt.com/codex/tasks/task_e_68d69fee2264833393b9740e1d68dcf2